### PR TITLE
Temporary solution to #367 while awaiting clarification from @Heinermann

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameMenu.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameMenu.cpp
@@ -301,7 +301,6 @@ namespace BWAPI
           i->container.bHumanSlots    = 8;
           for ( int p = 0; p < PLAYABLE_PLAYER_COUNT; ++p )
             i->container.bPlayerSlotEnabled[p] = 1;
-          i->container.bEntryFlags = 0x04;
 
           // Safe string copies
           SSCopy(i->container.szEntryName, mapFileName.c_str());


### PR DESCRIPTION
Skip setting bEntryFlags to 0x04. This got the replays rolling again and normal single player automation also seems to work fine. 

This is just a temporary black box fix in order to get the data mining people on track. Review/clarification from someone familiar with the internals of the BW binary is required to make sure it doesn't lead to any unwanted side-effects.
