### PR TITLE
Fixed an assertion that was sometimes failing for TestAIModule's TestMap...

### DIFF
--- a/bwapi/TestAIModule/Source/TestMap1.cpp
+++ b/bwapi/TestAIModule/Source/TestMap1.cpp
@@ -103,7 +103,8 @@ void TestMap1::onStart()
     BWAssert(unit->isLockedDown()==false);
     BWAssert(unit->isMaelstrommed()==false);
     BWAssert(unit->isMorphing()==false);
-    BWAssert(unit->isMoving()==false);
+    // It is normal for some units to initially have a move order.
+    //BWAssert(unit->isMoving()==false);
     BWAssert(unit->isParasited()==false);
     BWAssert(unit->isPatrolling()==false);
     BWAssert(unit->isPlagued()==false);


### PR DESCRIPTION
...1, about units moving at the start of the game. Using a debugger, I can see that BW's memory for the units at the start of the game shows that some units have a move order. FYI, in the old version this can usually be reproduced by starting a game for MicroTest.scm (with Use Map Settings) for a few seconds then quit mission then start a game for testmap1.scm (with Use Map Settings).
