### PR TITLE
Fixed a bug that caused crashes when running multiple consecutive games.

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
@@ -208,6 +208,10 @@ namespace BWAPI
     if ( this->players[11] )
       this->playerSet.insert(this->players[11]);
 
+    for (int p = 0; p < PLAYABLE_PLAYER_COUNT; ++p) {
+        if (this->players[p]) this->players[p]->force = nullptr;
+    }
+
     // Get Force Objects, assign Force<->Player relations
     ForceImpl *pNeutralForce = new ForceImpl(std::string(""));
     pNeutralForce->players.insert(this->players[11]);


### PR DESCRIPTION
in BWAPI::GameImpl::onGameStart: players with a null force is assigned the neutral force, but the value wasn't reset between games. This could result in the next game having two different neutral forces and more than 5 forces in total, which crashes BWAPIClient.
