### PR TITLE
Fixed Goliath air weapon and maxGroundHits() for siege tanks

### DIFF
--- a/bwapi/BWAPILIB/Source/UnitType.cpp
+++ b/bwapi/BWAPILIB/Source/UnitType.cpp
@@ -1103,7 +1103,7 @@ namespace BWAPI
       None, None, None, Unknown
     };
     static const WeaponType airWeapon[UnitTypes::Enum::MAX] = {
-      Gauss_Rifle, C_10_Canister_Rifle, None, None, Hellfire_Missile_Pack, None, None, None, Gemini_Missiles, None, None, None, 
+      Gauss_Rifle, C_10_Canister_Rifle, None, Hellfire_Missile_Pack, Hellfire_Missile_Pack, None, None, None, Gemini_Missiles, None, None, None, 
       ATA_Laser_Battery, None, None, None, C_10_Canister_Rifle_Sarah_Kerrigan, None, Hellfire_Missile_Pack_Alan_Schezar, None, 
       Gauss_Rifle_Jim_Raynor, Gemini_Missiles_Tom_Kazansky, None, None, None, None, None, ATA_Laser_Battery_Hero, 
       ATA_Laser_Battery_Hyperion, ATA_Laser_Battery_Hero, None, None, None, None, None, None, None, None, Needle_Spines, None, 
@@ -1124,7 +1124,7 @@ namespace BWAPI
   }
 
   static const int groundWeaponHits[UnitTypes::Enum::MAX] = {
-    1, 1, 1, 0, 1, 0, 1, 1, 1, 0, 3, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 1, 3, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 3, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 3, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 
     1, 1, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 2, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 2, 1, 1, 1, 0, 0, 0, 0, 1, 
     1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
@@ -1132,7 +1132,7 @@ namespace BWAPI
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
   };
   static const int airWeaponHits[UnitTypes::Enum::MAX] = {
-    1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 
+    1, 1, 0, 2, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 
     1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 4, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 
     1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 


### PR DESCRIPTION
Goliath air weapon is Hellfire_Missile_Pack (was None) with maxAirHits 2 (was 0), and siege tanks (sieged and tank mode) maxGroundHits is 1 (was 0)
