### PR TITLE
Fixed getID() returning -1 for some units acquired through getOrderTarge...

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameUnits.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameUnits.cpp
@@ -234,12 +234,10 @@ namespace BWAPI
       u->startingAttack           = airWeaponCooldown > u->lastAirWeaponCooldown || groundWeaponCooldown > u->lastGroundWeaponCooldown;
       u->lastAirWeaponCooldown    = airWeaponCooldown;
       u->lastGroundWeaponCooldown = groundWeaponCooldown;
+      if (u->getID() == -1)
+        u->setID(server.getUnitID(u));
       if (u->canAccess())
-      {
-        if (u->getID() == -1)
-          u->setID(server.getUnitID(u));
         u->updateData();
-      }
       if ( u->getOriginalRawData->unitType == UnitTypes::Terran_Ghost)
       {
         if (u->getOriginalRawData->orderID == Orders::NukePaint)


### PR DESCRIPTION
...t etc.

Units did not have their ID set until they were first accessible, so if you somehow got the pointer to a unit that was never accessible, its getID() would return -1.
