### PR TITLE
Fixed some fields (in particular isVisible) not being reset for destroye...

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/UnitImpl.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/UnitImpl.cpp
@@ -172,8 +172,6 @@ namespace BWAPI
 
   void UnitImpl::die()
   {
-    //set pointers to null so we don't read information from unit table anymore
-    getOriginalRawData = nullptr;
     index              = 0xFFFF;
     userSelected       = false;
     isAlive            = false;
@@ -186,6 +184,11 @@ namespace BWAPI
     lastPlayer         = nullptr;
     this->clientInfo.clear();
     this->interfaceEvents.clear();
+
+    updateInternalData();
+
+    //set pointers to null so we don't read information from unit table anymore
+    getOriginalRawData = nullptr;
 
     updateData();
   }

--- a/bwapi/BWAPI/Source/BWAPI/UnitUpdate.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/UnitUpdate.cpp
@@ -154,6 +154,7 @@ namespace BWAPI
       //------------------------------------------------------------------------------------------------------
       //isVisible
       MemZero(self->isVisible);
+      self->isDetected = false;
 
       _getPlayer          = nullptr;               //_getPlayer
       _getType            = UnitTypes::Unknown; //_getType


### PR DESCRIPTION
...d units.

When a unit is destroyed, all fields should reset to inaccessible values.
Fields which are updated in updateInternalData was not reset (visible, detected, player, type, transport, position, hitpoints, resources, build queue slot and isCompleted).
