### PR TITLE
Fix unitCompleted event being sent in the wrong time if bwapi used for several games

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameUnits.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameUnits.cpp
@@ -161,7 +161,7 @@ namespace BWAPI
       {
         if ( !u->wasAlive )
           events.push_back(Event::UnitCreate(u));
-        if ( !u->wasCompleted && u->isCompleted() )
+        if ( !u->wasCompleted && u->_isCompleted )
         {
           events.push_back(Event::UnitComplete(u));
           u->wasCompleted = true;


### PR DESCRIPTION
This should fix issue #553, reasoning for this change explained there.