### PR TITLE
Fix UnitCompleted event not being sent for units after morphing.

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameUnits.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameUnits.cpp
@@ -386,6 +386,7 @@ namespace BWAPI
       UnitImpl *u = static_cast<UnitImpl*>(ui);
       if (u->lastType != u->_getType && u->lastType != UnitTypes::Unknown && u->_getType != UnitTypes::Unknown)
       {
+        u->wasCompleted = false; // After morphing units mostly are not completed
         events.push_back(Event::UnitMorph(u));
         if (u->lastType == UnitTypes::Resource_Vespene_Geyser)
         {


### PR DESCRIPTION
So as I noticed at least in most of the cases for units after morphing `isCompleted` becomes false after they morphed and stays so until they fully built / spawned, this includes refineries and zerg units. Actually, while for zerg units there is another `UnitMorph` event sent after their spawned from egg / cocoon, for refinery it seems like there's no way to understand when it becomes completed.

Anyway it seems like it's right behavior to send `UnitCompleted` each time `IsCompleted` is changed from `false` to `true`, so I believe `wasCompleted` needs to be reset just after the unit was morphed.