### PR TITLE
auto_menu: added game_type_extra option to bwapi.ini

### DIFF
--- a/Release_Binary/Starcraft/bwapi-data/bwapi.ini
+++ b/Release_Binary/Starcraft/bwapi-data/bwapi.ini
@@ -74,6 +74,17 @@ enemy_race_7 = Default
 ;           | GREED | SLAUGHTER | SUDDEN_DEATH | TEAM_MELEE | TEAM_FREE_FOR_ALL | TEAM_CAPTURE_THE_FLAG
 game_type = MELEE
 
+; game_type_extra = Text that appears in the drop-down list below the Game Type drop-down list.
+; If empty, the Starcraft default will be used.
+; The following are the game types that use this setting, and corresponding example values
+;   TOP_VS_BOTTOM          3 vs 1 | 2 vs 2 | 1 vs 3 | # vs #
+;   GREED                  2500 | 5000 | 7500 | 10000
+;   SLAUGHTER              15 | 30 | 45 | 60
+;   TEAM_MELEE             2 | 3 | 4 | 5 | 6 | 7 | 8
+;   TEAM_FREE_FOR_ALL      2 | 3 | 4 | 5 | 6 | 7 | 8
+;   TEAM_CAPTURE_THE_FLAG  2 | 3 | 4 | 5 | 6 | 7 | 8
+game_type_extra =
+
 ; save_replay = path to save replay to
 ; Accepts all environment variables including custom variables. See wiki for more info.
 save_replay = maps/replays/%BOTNAME6%/$Y $b $d/%MAP%_%BOTRACE%%ALLYRACES%vs%ENEMYRACES%_$H$M$S.rep

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
@@ -113,6 +113,7 @@ void AutoMenuManager::reloadConfig()
   this->autoMenuEnemyCount = std::min(std::max(this->autoMenuEnemyCount, 0U), 7U);
 
   this->autoMenuGameType = LoadConfigStringUCase("auto_menu", "game_type", "MELEE");
+  this->autoMenuGameTypeExtra = LoadConfigString("auto_menu", "game_type_extra", "");
   this->autoMenuSaveReplay = LoadConfigString("auto_menu", "save_replay");
 
   this->autoMenuMinPlayerCount = LoadConfigInt("auto_menu", "wait_for_min_players", 2);
@@ -245,8 +246,34 @@ void AutoMenuManager::onMenuFrame()
 
         // retrieve gametype dropdown
         BW::dialog *gameTypeDropdown = tempDlg->findIndex(17);
+        if (!gameTypeDropdown)
+          break;
+
         if (gt != GameTypes::None && gt != GameTypes::Unknown && (int)gameTypeDropdown->getSelectedValue() != gt)
+        {
           gameTypeDropdown->setSelectedByValue(gt);
+          break;
+        }
+
+        // game types with an extra settings dropdown
+        if (gt == GameTypes::Top_vs_Bottom ||
+            gt == GameTypes::Greed ||
+            gt == GameTypes::Slaughter ||
+            gt == GameTypes::Team_Melee ||
+            gt == GameTypes::Team_Free_For_All ||
+            gt == GameTypes::Team_Capture_The_Flag)
+        {
+          BW::dialog* extraDropdown = tempDlg->findIndex(18);
+          if (!extraDropdown || std::string(extraDropdown->getSelectedString()).empty())
+            break;
+          
+          if (!this->autoMenuGameTypeExtra.empty() &&
+            extraDropdown->getSelectedString() != this->autoMenuGameTypeExtra)
+          {
+            extraDropdown->setSelectedByString(this->autoMenuGameTypeExtra);
+            break;
+          }
+        }
 
         // if this is single player
         if (isAutoSingle)

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.h
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.h
@@ -32,6 +32,7 @@ namespace BWAPI
     std::string autoMenuLanMode;
     std::string autoMenuRestartGame;
     std::string autoMenuGameType;
+    std::string autoMenuGameTypeExtra;
     std::string autoMenuGameName;
     unsigned lastAutoMapEntry = 0;
     std::string lastMapGen;


### PR DESCRIPTION
e.g. for selecting 2 vs 2 for game_type TOP_VS_BOTTOM or 7500 for GREED

it works by using setSelectedByString() and seems to work for all game types