### PR TITLE
console opening and output streams

### DIFF
--- a/Release_Binary/Starcraft/bwapi-data/bwapi.ini
+++ b/Release_Binary/Starcraft/bwapi-data/bwapi.ini
@@ -120,6 +120,25 @@ holiday = ON
 ; Setting this to OFF will disable the BWAPI Server, default is ON
 shared_memory = ON
 
+; console_* = TRUE | FALSE
+; Used for getting a console for displaying text written to stdout and stderr, and read from stdin.
+; console_attach_*
+;   Allows BWAPI to attach to the parent process' console. i.e. if the parent
+;   has a console, output will be displayed on that console, and that console
+;   also kept open even if the parent dies.
+; console_alloc_*
+;   Allows BWAPI to allocate it's own system console window. Not executed if
+;   corresponding console_attach_* is enabled and succeeds.
+; console_*_on_startup
+;   Executes when BWAPI.dll is first attached to Starcraft.
+; console_*_auto
+;   Executes when something is written to std::cout or std::cerr,
+;   and no console was successfully attached/allocated on startup.
+console_attach_on_startup = FALSE
+console_alloc_on_startup = FALSE
+console_attach_auto = TRUE
+console_alloc_auto = TRUE
+
 [window]
 ; These values are saved automatically when you move, resize, or toggle windowed mode
 

--- a/bwapi/BWAPI/BWAPI.vcxproj
+++ b/bwapi/BWAPI/BWAPI.vcxproj
@@ -352,7 +352,17 @@ popd</Command>
     <ClCompile Include="Source\Thread.cpp" />
     <ClCompile Include="Source\WMode.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\boost.1.59.0.0\build\native\boost.targets" Condition="Exists('..\packages\boost.1.59.0.0\build\native\boost.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\boost.1.59.0.0\build\native\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.59.0.0\build\native\boost.targets'))" />
+  </Target>
 </Project>

--- a/bwapi/BWAPI/BWAPI.vcxproj
+++ b/bwapi/BWAPI/BWAPI.vcxproj
@@ -226,6 +226,7 @@ popd</Command>
     <ClInclude Include="..\include\BWAPI\Interface.h" />
     <ClInclude Include="..\include\BWAPI\Player.h" />
     <ClInclude Include="..\include\BWAPI\Region.h" />
+    <ClInclude Include="..\include\BWAPI\Streams.h" />
     <ClInclude Include="..\include\BWAPI\Unit.h" />
     <ClInclude Include="..\Shared\Templates.h" />
     <ClInclude Include="Source\Assembly.h" />
@@ -320,6 +321,7 @@ popd</Command>
     <ClCompile Include="Source\BWAPI\PlayerImpl.cpp" />
     <ClCompile Include="Source\BWAPI\RegionImpl.cpp" />
     <ClCompile Include="Source\BWAPI\Server.cpp" />
+    <ClCompile Include="Source\BWAPI\Streams.cpp" />
     <ClCompile Include="Source\BWAPI\UnitImpl.cpp" />
     <ClCompile Include="Source\BWAPI\UnitUpdate.cpp" />
     <ClCompile Include="Source\BW\Bitmap.cpp" />

--- a/bwapi/BWAPI/BWAPI.vcxproj.filters
+++ b/bwapi/BWAPI/BWAPI.vcxproj.filters
@@ -428,4 +428,7 @@
       <Filter>BWAPI\Source</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/bwapi/BWAPI/BWAPI.vcxproj.filters
+++ b/bwapi/BWAPI/BWAPI.vcxproj.filters
@@ -256,6 +256,9 @@
     <ClInclude Include="Source\BW\Structures.h">
       <Filter>BW\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\BWAPI\Streams.h">
+      <Filter>Interface</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\BW\CheatType.cpp">
@@ -425,6 +428,9 @@
       <Filter>BWAPI\Source</Filter>
     </ClCompile>
     <ClCompile Include="Source\BWAPI\AutoMenuManager.cpp">
+      <Filter>BWAPI\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\BWAPI\Streams.cpp">
       <Filter>BWAPI\Source</Filter>
     </ClCompile>
   </ItemGroup>

--- a/bwapi/BWAPI/Source/BWAPI/Streams.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/Streams.cpp
@@ -1,0 +1,94 @@
+#include <BWAPI/Streams.h>
+#include <BWAPI/BroodwarOutputDevice.h>
+
+#pragma warning(push)
+#pragma warning(disable: 4127) //conditional expression is constant
+#pragma warning(disable: 4512) //assignment operator could not be generated
+#pragma warning(disable: 4702) //unreachable code
+#include <boost/iostreams/tee.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
+#pragma warning(pop)
+
+//for openConsole()
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#include <tchar.h>
+
+
+namespace BWAPI
+{
+  namespace io = boost::iostreams;
+
+  class OpenConsoleFilter : public io::multichar_dual_use_filter
+  {
+    bool attach;
+    bool alloc;
+  public:
+    OpenConsoleFilter(bool attach, bool alloc)
+      : attach(attach)
+      , alloc(alloc)
+    {}
+
+    template<typename Sink>
+    std::streamsize write(Sink& snk, const char* s, std::streamsize n) const
+    {
+      openConsole(attach, alloc);
+      return io::write(snk, s, n);
+    }
+
+    template<typename Source>
+    std::streamsize read(Source& src, char* s, std::streamsize n) const
+    {
+      openConsole(attach, alloc);
+      return io::read(src, s, n);
+    }
+  };
+  BOOST_IOSTREAMS_PIPABLE(OpenConsoleFilter, 0)
+
+
+
+  bool openConsole(bool attach, bool alloc)
+  {
+    if ((attach && AttachConsole(ATTACH_PARENT_PROCESS)) || (alloc && AllocConsole()))
+    {
+      *stdin  = *_tfdopen(_open_osfhandle(reinterpret_cast<intptr_t>(::GetStdHandle(STD_INPUT_HANDLE)), _O_RDONLY), _T("r"));
+      *stdout = *_tfdopen(_open_osfhandle(reinterpret_cast<intptr_t>(::GetStdHandle(STD_OUTPUT_HANDLE)), _O_WRONLY), _T("a"));
+      *stderr = *_tfdopen(_open_osfhandle(reinterpret_cast<intptr_t>(::GetStdHandle(STD_ERROR_HANDLE)), _O_WRONLY), _T("a"));
+
+      //make cout, wcout, cin, wcin, wcerr, cerr, wclog and clog point to console as well
+      std::ios::sync_with_stdio(true);
+      return true;
+    }
+    else
+      return false;
+  }
+
+  void autoOpenConsole(bool attach, bool alloc)
+  {
+    // putting cin in a filtering_ostreambuf makes it stop responding directly on Enter keypresses, and instead
+    // you need to press Ctrl+C the same amount of times as the number of elements in the filter chain.
+    //static io::filtering_istreambuf auto_cin_buf(OpenConsoleFilter(attach, alloc) | boost::ref(*std::cin.rdbuf()));
+    static io::filtering_ostreambuf auto_cout_buf(OpenConsoleFilter(attach, alloc) | boost::ref(*std::cout.rdbuf()));
+    static io::filtering_ostreambuf auto_cerr_buf(OpenConsoleFilter(attach, alloc) | boost::ref(*std::cerr.rdbuf()));
+    //std::cin.rdbuf(&auto_opening_cin_buf);
+    std::cout.rdbuf(&auto_cout_buf);
+    std::cerr.rdbuf(&auto_cerr_buf);
+  }
+
+
+
+  using bwstream = io::stream<BroodwarOutputDevice>;
+  using teestream = io::stream<io::tee_device<std::ostream, std::ostream>>;
+
+  BroodwarOutputDevice bwout_device;
+  BroodwarOutputDevice bwerr_device(Text::BrightRed);
+  bwstream bwout_stream(bwout_device);
+  bwstream bwerr_stream(bwerr_device);
+  std::ostream& bwout = bwout_stream;
+  std::ostream& bwerr = bwerr_stream;
+  teestream out_stream(io::tee(std::cout, bwout));
+  teestream err_stream(io::tee(std::cerr, bwerr));
+  std::ostream& out = out_stream;
+  std::ostream& err = err_stream;
+}

--- a/bwapi/BWAPI/Source/BWAPI/Streams.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/Streams.cpp
@@ -68,12 +68,14 @@ namespace BWAPI
   {
     // putting cin in a filtering_ostreambuf makes it stop responding directly on Enter keypresses, and instead
     // you need to press Ctrl+C the same amount of times as the number of elements in the filter chain.
-    //static io::filtering_istreambuf auto_cin_buf(OpenConsoleFilter(attach, alloc) | boost::ref(*std::cin.rdbuf()));
-    static io::filtering_ostreambuf auto_cout_buf(OpenConsoleFilter(attach, alloc) | boost::ref(*std::cout.rdbuf()));
-    static io::filtering_ostreambuf auto_cerr_buf(OpenConsoleFilter(attach, alloc) | boost::ref(*std::cerr.rdbuf()));
-    //std::cin.rdbuf(&auto_opening_cin_buf);
-    std::cout.rdbuf(&auto_cout_buf);
-    std::cerr.rdbuf(&auto_cerr_buf);
+    static std::streambuf& orig_cout_buf(*std::cout.rdbuf());
+    static std::streambuf& orig_cerr_buf(*std::cerr.rdbuf());
+    static std::unique_ptr<io::filtering_ostreambuf> auto_cout_buf;
+    static std::unique_ptr<io::filtering_ostreambuf> auto_cerr_buf;
+    auto_cout_buf = std::make_unique<io::filtering_ostreambuf>(OpenConsoleFilter(attach, alloc) | boost::ref(orig_cout_buf));
+    auto_cerr_buf = std::make_unique<io::filtering_ostreambuf>(OpenConsoleFilter(attach, alloc) | boost::ref(orig_cerr_buf));
+    std::cout.rdbuf(auto_cout_buf.get());
+    std::cerr.rdbuf(auto_cerr_buf.get());
   }
 
 

--- a/bwapi/BWAPI/Source/BWAPI/Streams.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/Streams.cpp
@@ -60,8 +60,7 @@ namespace BWAPI
       std::ios::sync_with_stdio(true);
       return true;
     }
-    else
-      return false;
+    return false;
   }
 
   void autoOpenConsole(bool attach, bool alloc)

--- a/bwapi/BWAPI/Source/DLLMain.cpp
+++ b/bwapi/BWAPI/Source/DLLMain.cpp
@@ -24,6 +24,7 @@
 #include "WMode.h"
 
 #include "../../Debug.h"
+#include <BWAPI/Streams.h>
 
 //---------------------------------------------- QUEUE COMMAND -----------------------------------------------
 void __fastcall QueueGameCommand(void *pBuffer, size_t dwLength)
@@ -217,6 +218,14 @@ BOOL APIENTRY DllMain(HMODULE, DWORD ul_reason_for_call, LPVOID)
     break;
   case DLL_PROCESS_ATTACH:
   {
+    bool attach_s = LoadConfigStringUCase("config", "console_attach_on_startup", "FALSE") == "TRUE";
+    bool alloc_s  = LoadConfigStringUCase("config", "console_alloc_on_startup",  "FALSE") == "TRUE";
+    bool attach_a = LoadConfigStringUCase("config", "console_attach_auto", "TRUE") == "TRUE";
+    bool alloc_a =  LoadConfigStringUCase("config", "console_alloc_auto",  "TRUE") == "TRUE";
+
+    if (!BWAPI::openConsole(attach_s, alloc_s))
+      BWAPI::autoOpenConsole(attach_a, alloc_a);
+
     static char szEventName[32];  // The name of the event, unique for this process
     sprintf(szEventName, "BWAPI #%u", GetCurrentProcessId());
 

--- a/bwapi/BWAPI/packages.config
+++ b/bwapi/BWAPI/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.59.0.0" targetFramework="native" />
+</packages>

--- a/bwapi/BWAPILIB/BWAPILIB.vcxproj
+++ b/bwapi/BWAPILIB/BWAPILIB.vcxproj
@@ -236,7 +236,17 @@ COPY /y "$(OutDir)BWAPILibd.pdb" "..\lib\BWAPILibd.pdb"
     <ClInclude Include="..\include\BWAPI\UpgradeType.h" />
     <ClInclude Include="..\include\BWAPI\WeaponType.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\boost.1.59.0.0\build\native\boost.targets" Condition="Exists('..\packages\boost.1.59.0.0\build\native\boost.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\boost.1.59.0.0\build\native\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.59.0.0\build\native\boost.targets'))" />
+  </Target>
 </Project>

--- a/bwapi/BWAPILIB/BWAPILIB.vcxproj
+++ b/bwapi/BWAPILIB/BWAPILIB.vcxproj
@@ -199,6 +199,7 @@ COPY /y "$(OutDir)BWAPILibd.pdb" "..\lib\BWAPILibd.pdb"
   <ItemGroup>
     <ClInclude Include="..\include\BWAPI\AIModule.h" />
     <ClInclude Include="..\include\BWAPI\BestFilter.h" />
+    <ClInclude Include="..\include\BWAPI\BroodwarOutputDevice.h" />
     <ClInclude Include="..\include\BWAPI\Bulletset.h" />
     <ClInclude Include="..\include\BWAPI\BulletType.h" />
     <ClInclude Include="..\include\BWAPI\Color.h" />

--- a/bwapi/BWAPILIB/BWAPILIB.vcxproj.filters
+++ b/bwapi/BWAPILIB/BWAPILIB.vcxproj.filters
@@ -220,4 +220,7 @@
       <UniqueIdentifier>{e2978001-1978-4c91-96da-927212cbf403}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/bwapi/BWAPILIB/BWAPILIB.vcxproj.filters
+++ b/bwapi/BWAPILIB/BWAPILIB.vcxproj.filters
@@ -190,6 +190,7 @@
     <ClInclude Include="..\include\BWAPI\SetContainer.h">
       <Filter>Containers\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\BWAPI\BroodwarOutputDevice.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Types">

--- a/bwapi/BWAPILIB/packages.config
+++ b/bwapi/BWAPILIB/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.59.0.0" targetFramework="native" />
+</packages>

--- a/bwapi/include/BWAPI.h
+++ b/bwapi/include/BWAPI.h
@@ -32,6 +32,7 @@
 #include <BWAPI/Race.h>
 #include <BWAPI/Region.h>
 #include <BWAPI/Regionset.h>
+#include <BWAPI/Streams.h>
 #include <BWAPI/TechType.h>
 #include <BWAPI/TournamentAction.h>
 #include <BWAPI/Type.h>

--- a/bwapi/include/BWAPI/BroodwarOutputDevice.h
+++ b/bwapi/include/BWAPI/BroodwarOutputDevice.h
@@ -1,0 +1,95 @@
+#pragma once
+#include <BWAPI/Game.h>
+#include <BW/Offsets.h>
+#include <BW/Font.h>
+#include <sstream>
+#include <boost/circular_buffer.hpp>
+
+#pragma warning(push)
+#pragma warning(disable: 4702) //unreachable code
+#include <boost/iostreams/stream.hpp>
+#pragma warning(pop)
+
+namespace BWAPI
+{
+  ///<summary>Output device for writing text to the screen as a notification.</summary>
+  /// Normally when you write stuff in Starcraft, the text wraps at word boundaries when it would
+  /// otherwise exceed the screen width. When this happens any Text::Enum color in the message is lost and
+  /// the next line will be some default color. To fix this color problem this device keeps track of
+  /// the width of the text in the buffer and manually wraps when needed (not on word boundaries), and
+  /// then colors the next line with the current color again before continuing to write.
+  /// @since 4.1.3
+  class BroodwarOutputDevice : public boost::iostreams::sink
+  {
+    static const int max_width = 620; //620 is the max width before starcraft wraps on it's own
+
+    int bufferWidth;
+    std::stringbuf buffer;
+    Text::Enum defaultColor;
+    boost::circular_buffer<Text::Enum> previousColors;
+
+  public:
+    explicit BroodwarOutputDevice(Text::Enum defaultColor = Text::Yellow)
+      : bufferWidth(0)
+      , defaultColor(defaultColor)
+      , previousColors(128) //arbitrary stack size
+    {
+      assert(Text::isColor(defaultColor));
+      buffer.sputc(char(defaultColor));
+      previousColors.push_back(defaultColor);
+    }
+
+    BroodwarOutputDevice(const BroodwarOutputDevice& o)
+      : BroodwarOutputDevice(o.defaultColor)
+    {}
+
+    std::streamsize write(const char* s, std::streamsize n)
+    {
+      for (int j = 0; j < n; j++)
+      {
+        char c = s[j];
+
+        //push/pop colors
+        if (Text::isColor(static_cast<Text::Enum>(c)))
+          previousColors.push_back(static_cast<Text::Enum>(c));
+        else if (c == Text::Previous)
+        {
+          previousColors.pop_back();
+          if (previousColors.empty()) //always keep a color on the stack
+            previousColors.push_back(defaultColor);
+          c = char(previousColors.back());
+        }
+
+        if (c == '\n' || bufferWidth + charWidth(c) > max_width)
+        {
+          BroodwarPtr->printf("%s", buffer.str().c_str());
+          buffer.str("");
+          buffer.sputc(char(previousColors.back()));
+          bufferWidth = 0;
+        }
+
+        if (c != '\n')
+        {
+          buffer.sputc(c);
+          bufferWidth += charWidth(c);
+        }
+      }
+      return n;
+    }
+
+  private:
+    int charWidth(char c) const
+    {
+      const BW::Font& font = *BW::BWDATA::FontBase[Text::Size::Default];
+      int mw = font.maxWidth();
+      if (c == ' ')
+        return mw / 2;
+      else if (c == '\t')
+        return mw * 2 - bufferWidth % (mw * 2);
+      else if (font.getChar(c))
+        return font.getChar(c)->width() + 1;
+      else
+        return 0;
+    }
+  };
+}

--- a/bwapi/include/BWAPI/Color.h
+++ b/bwapi/include/BWAPI/Color.h
@@ -185,6 +185,13 @@ namespace BWAPI
       Turquoise    = 31
     };
 
+    /// @returns true if \p c is a regular color, not Text::Previous, Text::Invisible* or Text::Align*
+    /// @since 4.1.3
+    inline bool isColor(Text::Enum c)
+    {
+      return 2<=c&&c<=8 || 14<=c&&c<=17 || 21<=c&&c<=31;
+    }
+
     /// <summary>Namespace containing text sizes.</summary>
     namespace Size
     {

--- a/bwapi/include/BWAPI/Color.h
+++ b/bwapi/include/BWAPI/Color.h
@@ -185,11 +185,12 @@ namespace BWAPI
       Turquoise    = 31
     };
 
+    /// <summary>Checks if the given character is a color-changing control code.</summary>
     /// @returns true if \p c is a regular color, not Text::Previous, Text::Invisible* or Text::Align*
-    /// @since 4.1.3
+    /// @since 4.2.0
     inline bool isColor(Text::Enum c)
     {
-      return 2<=c&&c<=8 || 14<=c&&c<=17 || 21<=c&&c<=31;
+      return (2 <= c && c <= 8) || (14 <= c && c <= 17) || (21 <= c && c <= 31);
     }
 
     /// <summary>Namespace containing text sizes.</summary>

--- a/bwapi/include/BWAPI/Streams.h
+++ b/bwapi/include/BWAPI/Streams.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <iostream>
+
+namespace BWAPI
+{
+  /// <summary>Tries to open a console for displaying text written to stdout and stderr, and read from stdin.</summary>
+  /// 
+  /// <param name="allowAttach">
+  ///   If true, try to attach to the parents' console.
+  /// </param>
+  /// <param name="allowAlloc">
+  ///   If true, and attaching is disabled or fails, allocate a new console (which should almost always succeed).
+  /// </param>
+  ///
+  /// @returns
+  ///   True if a console was successfully attached/allocated
+  ///
+  /// @see AttachConsole, AllocConsole
+  /// @since 4.1.3
+  bool openConsole(bool allowAttach, bool allowAlloc);
+
+  /// <summary>Make openConsole be called when something is written to std::cout or std::cerr.</summary>
+  /// @see openConsole
+  /// @since 4.1.3
+  void autoOpenConsole(bool allowAttach, bool allowAlloc);
+
+  /// <summary>Output stream that writes text to the screen as a notification.</summary>
+  /// Colored Text::Yellow by default, but preserves new Text::Enum colors written to it between lines.
+  /// Wraps text when needed, not on word boundaries.
+  /// 
+  /// @note Text printed from this stream is not seen by other players or in replays.
+  ///
+  /// @see Text::Enum, BroodwarOutputDevice
+  /// @since 4.1.3
+  extern std::ostream& bwout;
+  
+  /// <summary>An output stream like bwout, but colored Text::BrightRed by default</summary>
+  /// @see bwout
+  /// @since 4.1.3
+  extern std::ostream& bwerr;
+  
+  /// <summary>An output stream that writes to both std::cout and BWAPI::bwout.</summary>
+  /// @since 4.1.3
+  extern std::ostream& out;
+  
+  /// <summary>An output stream that writes to both std::cerr and BWAPI::bwerr.</summary>
+  /// @since 4.1.3
+  extern std::ostream& err;
+}

--- a/bwapi/include/BWAPI/Streams.h
+++ b/bwapi/include/BWAPI/Streams.h
@@ -16,12 +16,12 @@ namespace BWAPI
   ///   True if a console was successfully attached/allocated
   ///
   /// @see AttachConsole, AllocConsole
-  /// @since 4.1.3
+  /// @since 4.2.0
   bool openConsole(bool allowAttach, bool allowAlloc);
 
   /// <summary>Make openConsole be called when something is written to std::cout or std::cerr.</summary>
   /// @see openConsole
-  /// @since 4.1.3
+  /// @since 4.2.0
   void autoOpenConsole(bool allowAttach, bool allowAlloc);
 
   /// <summary>Output stream that writes text to the screen as a notification.</summary>
@@ -31,19 +31,19 @@ namespace BWAPI
   /// @note Text printed from this stream is not seen by other players or in replays.
   ///
   /// @see Text::Enum, BroodwarOutputDevice
-  /// @since 4.1.3
+  /// @since 4.2.0
   extern std::ostream& bwout;
   
   /// <summary>An output stream like bwout, but colored Text::BrightRed by default</summary>
   /// @see bwout
-  /// @since 4.1.3
+  /// @since 4.2.0
   extern std::ostream& bwerr;
   
   /// <summary>An output stream that writes to both std::cout and BWAPI::bwout.</summary>
-  /// @since 4.1.3
+  /// @since 4.2.0
   extern std::ostream& out;
   
   /// <summary>An output stream that writes to both std::cerr and BWAPI::bwerr.</summary>
-  /// @since 4.1.3
+  /// @since 4.2.0
   extern std::ostream& err;
 }


### PR DESCRIPTION
Addresses #627 by adding two functions, `openConsole()` and `autoOpenConsole()`, the first opens a console immediately, while the second will make it open when/if something is written to `std::cout/cerr`. Via bwapi.ini they which can also be configured to be called when bwapi is first attached.

It also adds 4 output streams: `BWAPI::bwout/bwerr` and `BWAPI::out/err`.
`bwout/bwerr` prints inside Starcraft via `Game::printf()` but bwerr is colored red.
`out/err` writes to both `bwout/bwerr` and `std::cout/cerr`.

Things I'm unsure about:
- The names for the streams, `BWAPI::bwout/bwerr` and `BWAPI::out/err`.
- This adds a dependency on boost, but only when compiling bwapi itself.
- In which folder/filter to include the files in visual studio.
- The version number in the @since tags (I used 4.1.3)

Possible improvements:
- Filter out `Text::Enum` colors printed via `BWAPI::out/err` from `std::cout/err` or replace them with terminal color codes.

Possible futures:  
- Replace `GameWrapper::operator<<`
- Start writing errors to stderr and exit Starcraft.