### PR TITLE
Allows each different AI module to select its own race when multiple …

### DIFF
--- a/Release_Binary/Starcraft/bwapi-data/bwapi.ini
+++ b/Release_Binary/Starcraft/bwapi-data/bwapi.ini
@@ -50,6 +50,11 @@ game =
 mapiteration = RANDOM
 
 ; race = Terran | Protoss | Zerg | Random
+;   - Use commas to specify race for each AI module when running multiple instances.
+;   - If there are more instances than the amount of 
+;         races specified, then the last entry is used.
+;	- To be used in conjunction with multiple AI modules
+;   - Example: Terran, Protoss, Terran, Zerg
 race = Terran
 
 ; enemy_count = 1-7, for 1v1 games, set enemy_count = 1

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
@@ -99,6 +99,19 @@ void AutoMenuManager::reloadConfig()
 
   this->autoMenuLanMode = LoadConfigString("auto_menu", "lan_mode", "Local Area Network (UDP)");
   this->autoMenuRace = LoadConfigStringUCase("auto_menu", "race", "RANDOM");
+  std::stringstream raceList(this->autoMenuRace);
+
+  std::string currentrace = this->autoMenuRace.substr(0, this->autoMenuRace.find_first_of(','));
+
+  for (int i = 0; i < (int)gdwProcNum && raceList; ++i)
+      std::getline(raceList, currentrace, ',');
+
+  auto trimBegin = currentrace.find_first_not_of(" \"");
+  auto trimEnd = currentrace.find_last_not_of(" \"") + 1;
+  currentrace = currentrace.substr(trimBegin, trimEnd - trimBegin);
+
+  this->autoMenuRace = currentrace;
+
   this->autoMenuEnemyRace[0] = LoadConfigStringUCase("auto_menu", "enemy_race", "RANDOM");
   for (unsigned int i = 1; i < 8; ++i)
   {


### PR DESCRIPTION
…instances are run

Allows for comma-separated values for the agent's race, identical to how
multiple AI modules can be supplied in bwapi.ini. Useful for running
multiple instances on Local PC.

While a niche change, it does not break any existing bwapi.ini configurations and offers extra functionality (which I am taking advantage of in my research).

I do apologise if I've done something incorrectly / outside of protocol. This is my first pull request. The code itself should follow most of the guidelines, as it is nearly a clone of the equivalent code from loading the AI modules based on instance. 