### PR TITLE
Some fixes to header include.

### DIFF
--- a/bwapi/DocumentationGen/playertypes.cpp
+++ b/bwapi/DocumentationGen/playertypes.cpp
@@ -1,5 +1,8 @@
 #include "helpers.h"
 
+#include <set>
+#include <string>
+
 void writePlayerTypeInfo()
 {
   std::ofstream of("playertypes.dox");

--- a/bwapi/DocumentationGen/techtypes.cpp
+++ b/bwapi/DocumentationGen/techtypes.cpp
@@ -1,5 +1,8 @@
 #include "helpers.h"
 
+#include <set>
+#include <string>
+
 void writeTechInfo()
 {
   std::ofstream of("techtypes.dox");

--- a/bwapi/DocumentationGen/unittypestestgen.cpp
+++ b/bwapi/DocumentationGen/unittypestestgen.cpp
@@ -1,5 +1,7 @@
 #include "helpers.h"
 
+#include <set>
+
 void genUnitTypeTest()
 {
   std::ofstream of("testUnitTypes.txt");

--- a/bwapi/include/BWAPI/SetContainer.h
+++ b/bwapi/include/BWAPI/SetContainer.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <unordered_set>
-#include <set>
 
 namespace BWAPI
 {
@@ -19,13 +18,8 @@ namespace BWAPI
   {
   public:
     SetContainer() : SetContainerUnderlyingT<T, HashT>() {}
-    SetContainer(SetContainer const &other) : SetContainerUnderlyingT<T, HashT>(other) {}
-    SetContainer(SetContainer &&other) : SetContainerUnderlyingT<T, HashT>(std::forward<SetContainer>(other)) {}
     SetContainer(std::initializer_list<T> ilist) : SetContainerUnderlyingT<T, HashT>(ilist) {}
-    SetContainer& operator=(const SetContainer& n) = default;
-    SetContainer& operator=(SetContainer&& n) = default;
 
-    
     template <class IterT>
     SetContainer(IterT _begin, IterT _end) : SetContainerUnderlyingT<T, HashT>(_begin, _end) {}
     


### PR DESCRIPTION
Summary:
We should include and only include headers that used in the .cpp file.
This commit fixes a few of such files.

Also it removes some redudant copy and move constructors of SetContainer
as they are implicitly defined thus unnecessary. This change compiles under VS2015.