### PR TITLE
Rename clamp.h to Clamp.h and sha1.{h,cpp} to Sha1.{h,cpp}.

### DIFF
--- a/bwapi/BWAPI/Source/BW/Bitmap.cpp
+++ b/bwapi/BWAPI/Source/BW/Bitmap.cpp
@@ -1,6 +1,6 @@
 #include "Bitmap.h"
 #include <storm.h>
-#include <util/clamp.h>
+#include <Util/Clamp.h>
 #include <algorithm>
 
 #include "Font.h"

--- a/bwapi/BWAPI/Source/BWAPI/GameDrawing.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameDrawing.cpp
@@ -2,7 +2,7 @@
 
 #include "../Graphics.h"
 #include <cassert>
-#include <Util/clamp.h>
+#include <Util/Clamp.h>
 #include <Util/Convenience.h>
 
 #include <BW/Dialog.h>

--- a/bwapi/BWAPI/Source/BWAPI/GameImpl.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameImpl.cpp
@@ -8,7 +8,7 @@
 #include <cmath>
 #include <fstream>
 
-#include <Util/clamp.h>
+#include <Util/Clamp.h>
 #include <Util/Convenience.h>
 
 #include <BWAPI/ForceImpl.h>

--- a/bwapi/BWAPI/Source/BWAPI/GameMenu.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameMenu.cpp
@@ -10,7 +10,7 @@
 #include <BW/MenuPosition.h>
 #include <BW/Dialog.h>
 #include <BW/OrderTypes.h>
-#include <Util/clamp.h>
+#include <Util/Clamp.h>
 
 #include "../../../Debug.h"
 

--- a/bwapi/BWAPI/Source/BWAPI/Map.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/Map.cpp
@@ -10,7 +10,7 @@
 #include "PlayerImpl.h"
 #include <fstream>
 #include <memory>
-#include <Util/sha1.h>
+#include <Util/Sha1.h>
 
 #include "../../../Debug.h"
 

--- a/bwapi/BWAPI/Source/DLLMain.cpp
+++ b/bwapi/BWAPI/Source/DLLMain.cpp
@@ -5,7 +5,7 @@
 #include <cassert>
 #include "Thread.h"
 
-#include <Util/clamp.h>
+#include <Util/Clamp.h>
 #include <Util/Convenience.h>
 
 #include <BWAPI.h>

--- a/bwapi/Util/Source/Util/Clamp.h
+++ b/bwapi/Util/Source/Util/Clamp.h
@@ -1,5 +1,5 @@
 #pragma once
-/*  clamp.h
+/*  Clamp.h
     clamping a value to be between a specified min and max value
 */
 #include <algorithm>

--- a/bwapi/Util/Source/Util/Sha1.cpp
+++ b/bwapi/Util/Source/Util/Sha1.cpp
@@ -31,7 +31,7 @@ Gustav
 Several members in the gamedev.se forum.
 */
  
-#include "sha1.h"
+#include "Sha1.h"
 #include <cstring>
 
 namespace sha1

--- a/bwapi/Util/Source/Util/Sha1.h
+++ b/bwapi/Util/Source/Util/Sha1.h
@@ -1,4 +1,4 @@
-// sha1.h and sha1.cpp are from code.google.com/p/smallsha1/
+// Sha1.h and Sha1.cpp are from code.google.com/p/smallsha1/
 /*
 Copyright (c) 2009, Micael Hildenborg
 All rights reserved.

--- a/bwapi/Util/Util.vcxproj
+++ b/bwapi/Util/Util.vcxproj
@@ -72,18 +72,18 @@
     <ClCompile Include="Source\Util\MemoryFrame.cpp" />
     <ClCompile Include="Source\Util\Mutex.cpp" />
     <ClCompile Include="Source\Util\RemoteProcess.cpp" />
-    <ClCompile Include="Source\Util\sha1.cpp" />
+    <ClCompile Include="Source\Util\Sha1.cpp" />
     <ClCompile Include="Source\Util\SharedMemory.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Source\Util\clamp.h" />
+    <ClInclude Include="Source\Util\Clamp.h" />
     <ClInclude Include="Source\Util\Convenience.h" />
     <ClInclude Include="Source\Util\Exceptions.h" />
     <ClInclude Include="Source\Util\MemoryFrame.h" />
     <ClInclude Include="Source\Util\Mutex.h" />
     <ClInclude Include="Source\Util\RemoteProcess.h" />
     <ClInclude Include="Source\Util\RemoteProcessID.h" />
-    <ClInclude Include="Source\Util\sha1.h" />
+    <ClInclude Include="Source\Util\Sha1.h" />
     <ClInclude Include="Source\Util\SharedMemory.h" />
     <ClInclude Include="Source\Util\SharedStructure.h" />
     <ClInclude Include="Source\Util\Types.h" />

--- a/bwapi/Util/Util.vcxproj.filters
+++ b/bwapi/Util/Util.vcxproj.filters
@@ -13,7 +13,7 @@
     <ClCompile Include="Source\Util\RemoteProcess.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Source\Util\sha1.cpp">
+    <ClCompile Include="Source\Util\Sha1.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Source\Util\SharedMemory.cpp">
@@ -36,7 +36,7 @@
     <ClInclude Include="Source\Util\RemoteProcessID.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Source\Util\sha1.h">
+    <ClInclude Include="Source\Util\Sha1.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Source\Util\SharedMemory.h">
@@ -48,7 +48,7 @@
     <ClInclude Include="Source\Util\Types.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Source\Util\clamp.h">
+    <ClInclude Include="Source\Util\Clamp.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Source\Util\Convenience.h">


### PR DESCRIPTION
All other file names follow the CamelCase convention. This commits fixes
these three files.