### PR TITLE
Local PC for win10 and more

### DIFF
--- a/Release_Binary/Starcraft/bwapi-data/bwapi.ini
+++ b/Release_Binary/Starcraft/bwapi-data/bwapi.ini
@@ -38,15 +38,15 @@ lan_mode = Local Area Network (UDP)
 ; and then BWAPI resume menu automation and start the next match
 auto_restart = OFF
 
-; map = path to map relative to Starcraft folder, i.e. map = maps/(2)Boxer.scm
+; map = path to map to host relative to Starcraft folder, i.e. map = maps/(2)Boxer.scm
 ; leaving this field blank will join a game instead of creating it
 ; The filename(NOT the path) can also contain wildcards, example: maps/(?)*.sc?
 ; A ? is a wildcard for a single character and * is a wildcard for a string of characters
 map = maps/(?)*.sc?
 
-; game = name of the game to join
-;	i.e., game = BWAPI
-;	will join the game called "BWAPI"
+; game = name of the game to join | JOIN_FIRST
+;	i.e. game = BWAPI will join the game called "BWAPI"
+;   and game = JOIN_FIRST will join the first game in the list.
 ;	If the game does not exist and the "map" entry is not blank, then the game will be created instead
 ;	If this entry is blank, then it will follow the rules of the "map" entry
 game = 

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <sstream>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string/trim.hpp>
 
 #include <BW/MenuPosition.h>
 #include <BW/Dialog.h>
@@ -108,9 +109,9 @@ void AutoMenuManager::reloadConfig()
   for (int i = 0; i < (int)gdwProcNum && raceList; ++i)
       std::getline(raceList, currentrace, ',');
 
-  auto trimBegin = currentrace.find_first_not_of(" \"");
-  auto trimEnd = currentrace.find_last_not_of(" \"") + 1;
-  currentrace = currentrace.substr(trimBegin, trimEnd - trimBegin);
+  // trim whitespace outside quotations and then the quotations
+  boost::trim(currentrace);
+  boost::trim_if(currentrace, boost::is_any_of("\""));
 
   this->autoMenuRace = currentrace;
 

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
@@ -35,7 +35,7 @@ void AutoMenuManager::reloadConfig()
 #endif
   this->autoMenuRestartGame = LoadConfigStringUCase("auto_menu", "auto_restart", "OFF");
   this->autoMenuGameName = LoadConfigString("auto_menu", "game");
-  this->autoMenuCharacterName = LoadConfigString("auto_menu", "character_name", "FIRST");
+  this->autoMenuCharacterName = LoadConfigString("auto_menu", "character_name", "FIRST").substr(0, 24);
 
   // Load map string
   std::string cfgMap = LoadConfigString("auto_menu", "map", "");

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
@@ -341,22 +341,23 @@ void AutoMenuManager::onMenuFrame()
     if (!tempDlg)
       break;
 
-    if (isJoining &&
-      !tempDlg->findIndex(5)->setSelectedByString(this->autoMenuGameName) &&
+    bool gameToJoinExists = tempDlg->findIndex(5)->setSelectedByString(this->autoMenuGameName) ||
+      (this->autoMenuGameName == "JOIN_FIRST" && tempDlg->findIndex(5)->getListCount() > 0);
+
+    if (isJoining && !gameToJoinExists &&
       waitJoinTimer + (3000 * (BroodwarImpl.getInstanceNumber() + 1)) > GetTickCount())
-      break;
+      break; //wait for game to be hosted
 
     waitJoinTimer = GetTickCount();
-    isHost = !(isJoining && tempDlg->findIndex(5)->setSelectedByString(this->autoMenuGameName));
 
-    if (isCreating && isHost)
-    {
-      pressDialogKey(tempDlg->findIndex(15));  // Create Game
-    }
-    else // is joining
+    if (gameToJoinExists)
     {
       this->lastMapGen.clear();
       pressDialogKey(tempDlg->findIndex(13));  // OK
+    }
+    else if (isCreating)
+    {
+      pressDialogKey(tempDlg->findIndex(15));  // Create Game
     }
   }
   break;
@@ -411,7 +412,6 @@ void AutoMenuManager::onMenuFrame()
     if (isCreating &&
       waitRestartTimer + 2000 < GetTickCount() &&
       !actStartedGame &&
-      isHost &&
       getLobbyPlayerReadyCount() > 0 &&
       getLobbyPlayerReadyCount() == getLobbyPlayerCount() &&
       (getLobbyPlayerReadyCount() >= this->autoMenuMinPlayerCount || getLobbyOpenCount() == 0))

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.h
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.h
@@ -52,7 +52,6 @@ namespace BWAPI
 
     bool actStartedGame = false;
     bool actRaceSel = false;
-    bool isHost = false;
 
 #ifdef _DEBUG
     std::string autoMenuPause;

--- a/bwapi/BWAPI/Source/Config.h
+++ b/bwapi/BWAPI/Source/Config.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <storm.h>
 #include "DLLMain.h"
+#include <boost/filesystem/path.hpp>
 
 // Functions
 std::string LoadConfigString(const char *pszKey, const char *pszItem, const char *pszDefault = NULL);
@@ -19,11 +20,8 @@ inline const std::string& installPath()
   if (path.empty())
   {
     char buffer[MAX_PATH];
-    if (GetModuleFileNameA(NULL, buffer, MAX_PATH))
-    {
-      path = std::string(buffer);
-      path = path.substr(0, path.find_last_of("\\/")+1);
-    }
+    if (GetModuleFileNameA(NULL, buffer, MAX_PATH)) //get .exe path
+      path = boost::filesystem::path(buffer).parent_path().string() + "\\";
     else
       BWAPIError("Error getting starcraft's root directory via GetModuleFileNameA()");
   }

--- a/bwapi/BWAPI/Source/GameUpdate.cpp
+++ b/bwapi/BWAPI/Source/GameUpdate.cpp
@@ -16,6 +16,7 @@
 
 #include "../../../svnrev.h"
 #include "../../../Debug.h"
+#include <boost/algorithm/string/trim.hpp>
 
 using namespace BWAPI;
 
@@ -362,10 +363,9 @@ void GameImpl::initializeAIModule()
       for (int i = 0; i < (int)gdwProcNum && aiList; ++i)
         std::getline(aiList, dll, ',');
 
-      // Trim leading and trailing spaces, and extra quotations
-      auto trimBegin = dll.find_first_not_of(" \"");
-      auto trimEnd = dll.find_last_not_of(" \"") + 1;
-      dll = dll.substr(trimBegin, trimEnd - trimBegin);
+      // trim whitespace outside quotations and then the quotations
+      boost::trim(dll);
+      boost::trim_if(dll, boost::is_any_of("\""));
 
       hAIModule = LoadLibraryA(dll.c_str());
     }

--- a/bwapi/SNP_DirectIP/SNP/LocalPC.cpp
+++ b/bwapi/SNP_DirectIP/SNP/LocalPC.cpp
@@ -39,7 +39,7 @@ namespace SMEM
     PeerData peer[8];
   };
   Util::SharedStructure<SharedData> session;
-  Util::Mutex mutex("Global\\LocalPC_Network_Mutex");
+  Util::Mutex mutex("Local\\LocalPC_Network_Mutex");
 
   SharedData *shd = NULL;
 
@@ -79,7 +79,7 @@ namespace SMEM
     INTERLOCKED;
 
     // init shared stuff
-    bool just_created = session.create("Global\\LocalPC_Network_Memory");
+    bool just_created = session.create("Local\\LocalPC_Network_Memory");
     shd = &session.get();
 
     // if the shared memory was just created, init it
@@ -113,7 +113,8 @@ namespace SMEM
   }
   void LocalPC::destroy()
   {
-    shd->peer[self].lastOccupied = 0;
+    if (shd)
+      shd->peer[self].lastOccupied = 0;
     session.release();
   }
   void LocalPC::requestAds()

--- a/bwapi/SNP_DirectIP/SNP/SNPModule.cpp
+++ b/bwapi/SNP_DirectIP/SNP/SNPModule.cpp
@@ -13,8 +13,6 @@ namespace SNP
   //------------------------------------------------------------------------------------------------------------------------------------
   Network<SOCKADDR> *pluggedNetwork = NULL;
 
-  bool fatalError = false;
-
   client_info gameAppInfo;
 
   CriticalSection critSec;
@@ -136,7 +134,6 @@ each second
     // Called when the module is loaded
 //    DropMessage(0, "spiInitialize");
 
-    fatalError = false;
     gameAppInfo = *gameClientInfo;
 
     receiveEvent = hEvent;
@@ -149,7 +146,6 @@ each second
     }
     catch(GeneralException &e)
     {
-      fatalError = true;
       DropLastError(__FUNCTION__ " unhandled exception: %s", e.getMessage());
       return FALSE;
     }
@@ -168,7 +164,6 @@ each second
     }
     catch(GeneralException &e)
     {
-      fatalError = true;
       DropLastError(__FUNCTION__ " unhandled exception: %s", e.getMessage());
       return FALSE;
     }
@@ -222,7 +217,6 @@ each second
     }
     catch(GeneralException &e)
     {
-      fatalError = true;
       DropLastError(__FUNCTION__ " unhandled exception: %s", e.getMessage());
       return FALSE;
     }
@@ -278,7 +272,6 @@ each second
     }
     catch(GeneralException &e)
     {
-      fatalError = true;
       DropLastError(__FUNCTION__ " unhandled exception: %s", e.getMessage());
       return FALSE;
     }

--- a/bwapi/Util/Source/Util/SharedMemory.cpp
+++ b/bwapi/Util/Source/Util/SharedMemory.cpp
@@ -45,10 +45,6 @@ namespace Util
 
     return !alreadyExisted;
   }
-  void SharedMemory::create(int size)
-  {
-    this->create(size, NULL);
-  }
   //----------------------- IMPORT -------------------------------------
   void SharedMemory::import(Export source)
   {

--- a/bwapi/Util/Source/Util/SharedMemory.h
+++ b/bwapi/Util/Source/Util/SharedMemory.h
@@ -57,8 +57,7 @@ namespace Util
     SharedMemory();
     ~SharedMemory();
 
-    void create(int size);                          // allocates memory
-    bool create(int size, const char* systemName);  // allocates memory, returns false if opened an existing named object
+    bool create(int size, const char* systemName = nullptr);  // allocates memory, returns false if opened an existing named object
     void import(Export source);     // connects to shared memory
     void release();                             // releases memory
     Export exportToProcess(RemoteProcess &target, bool readOnly) const;


### PR DESCRIPTION
This addresses #614 some smaller stuff. 

I'd very much like to have everything looked at. Some questions are:
Replacing `Global\\` with `Local\\` in LocalPC.cpp seems to fix #614 for me, but does it work on other windows versions?
Should both the shared memory and the mutex be local? I seems to work when the mutex is either.

Btw, we use the `Local\\` prefix for two other shared memories:
  - "Local\\bwapi_shared_memory_" << processID
  - "Local\\bwapi_shared_memory_game_list"