### PR TITLE
Use CallWndProc to call the original WndProc

### DIFF
--- a/bwapi/BWAPI/Source/WMode.cpp
+++ b/bwapi/BWAPI/Source/WMode.cpp
@@ -377,7 +377,7 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
       break;
     case WM_ACTIVATEAPP:
       if ( wOriginalProc )
-        return wOriginalProc(hWnd, WM_ACTIVATEAPP, (WPARAM)1, NULL);
+        return CallWindowProc(wOriginalProc, hWnd, WM_ACTIVATEAPP, (WPARAM)1, NULL);
     case WM_SETCURSOR:
     case WM_ERASEBKGND:
       return DefWindowProc(hWnd, uMsg, wParam, lParam);
@@ -456,7 +456,7 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
   // Call the original WndProc
   if ( wOriginalProc )
-    return wOriginalProc(hWnd, uMsg, wParam, lParam);
+    return CallWindowProc(wOriginalProc, hWnd, uMsg, wParam, lParam);
   return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
 


### PR DESCRIPTION
Calling wOriginalProc directly is not guaranteed to work as excepted.

https://msdn.microsoft.com/en-us/library/windows/desktop/ms633584(v=vs.85).aspx says "You must use the CallWindowProc function to call the window procedure."

At least on my system, this is necessary when using BWAPI with an OpenGL-based windowed mode hack, as the system's OpenGL driver injects its own *unicode* WndProc hook. 