### PR TITLE
Fix overflow in StrCopy

### DIFF
--- a/bwapi/BWAPIClient/Source/Convenience.h
+++ b/bwapi/BWAPIClient/Source/Convenience.h
@@ -19,8 +19,8 @@ inline void StrTerminate(char (&str)[N])
 template <size_t N>
 inline void StrCopy(char (&dst)[N], const char *src)
 {
-	strncpy(dst, src, N - 1);
-	StrTerminate(dst);
+  strncpy(dst, src, N - 1);
+  StrTerminate(dst);
 };
 
 template <size_t N>
@@ -28,7 +28,6 @@ inline void StrCopy(char (&dst)[N], const std::string &src)
 {
   StrCopy(dst, src.c_str());
 };
-
 
 template <size_t N>
 inline void VSNPrintf(char (&dst)[N], const char *fmt, va_list &ap)

--- a/bwapi/BWAPIClient/Source/Convenience.h
+++ b/bwapi/BWAPIClient/Source/Convenience.h
@@ -17,29 +17,16 @@ inline void StrTerminate(char (&str)[N])
 };
 
 template <size_t N>
-inline void StrCopy(char (&dst)[N], const char *src, int length = -1)
+inline void StrCopy(char (&dst)[N], const char *src)
 {
-	if (length == -1)
-	{
-	  length = 0;
-	  while (src[length] != '\0' &&
-			 length < N)
-	  {
-		++length;
-	  }
-	}
-	else if (length > N)
-	{
-		length = N;
-	}
-	std::copy(src, src + length, dst);
+	strncpy(src, dst, N - 1);
 	StrTerminate(dst);
 };
 
 template <size_t N>
 inline void StrCopy(char (&dst)[N], const std::string &src)
 {
-  StrCopy(dst, src.c_str(), src.length());
+  StrCopy(dst, src.c_str());
 };
 
 

--- a/bwapi/BWAPIClient/Source/Convenience.h
+++ b/bwapi/BWAPIClient/Source/Convenience.h
@@ -17,7 +17,7 @@ inline void StrTerminate(char (&str)[N])
 };
 
 template <size_t N>
-inline void StrCopy(char (&dst)[N], const char *src)
+inline void StrCopy(char (&dst)[N], char *src)
 {
 	strncpy(src, dst, N - 1);
 	StrTerminate(dst);

--- a/bwapi/BWAPIClient/Source/Convenience.h
+++ b/bwapi/BWAPIClient/Source/Convenience.h
@@ -17,16 +17,29 @@ inline void StrTerminate(char (&str)[N])
 };
 
 template <size_t N>
-inline void StrCopy(char (&dst)[N], const char *src)
+inline void StrCopy(char (&dst)[N], const char *src, int length = -1)
 {
-  std::copy(src, src + N, dst);
-  StrTerminate(dst);
+	if (length == -1)
+	{
+	  length = 0;
+	  while (src[length] != '\0' &&
+			 length < N)
+	  {
+		++length;
+	  }
+	}
+	else if (length > N)
+	{
+		length = N;
+	}
+	std::copy(src, src + length, dst);
+	StrTerminate(dst);
 };
 
 template <size_t N>
 inline void StrCopy(char (&dst)[N], const std::string &src)
 {
-  StrCopy(dst, src.c_str());
+  StrCopy(dst, src.c_str(), src.length());
 };
 
 

--- a/bwapi/BWAPIClient/Source/Convenience.h
+++ b/bwapi/BWAPIClient/Source/Convenience.h
@@ -17,9 +17,9 @@ inline void StrTerminate(char (&str)[N])
 };
 
 template <size_t N>
-inline void StrCopy(char (&dst)[N], char *src)
+inline void StrCopy(char (&dst)[N], const char *src)
 {
-	strncpy(src, dst, N - 1);
+	strncpy(dst, src, N - 1);
 	StrTerminate(dst);
 };
 

--- a/bwapi/Util/Source/Util/Convenience.h
+++ b/bwapi/Util/Source/Util/Convenience.h
@@ -21,16 +21,15 @@ inline void StrTerminate(char (&str)[N])
 template <size_t N>
 inline void StrCopy(char(&dst)[N], const char *src)
 {
-	strncpy(dst, src, N - 1);
-	StrTerminate(dst);
+  strncpy(dst, src, N - 1);
+  StrTerminate(dst);
 };
 
 template <size_t N>
 inline void StrCopy(char(&dst)[N], const std::string &src)
 {
-	StrCopy(dst, src.c_str());
+  StrCopy(dst, src.c_str());
 };
-
 
 template <size_t N>
 inline void VSNPrintf(char (&dst)[N], const char *fmt, va_list &ap)

--- a/bwapi/Util/Source/Util/Convenience.h
+++ b/bwapi/Util/Source/Util/Convenience.h
@@ -19,7 +19,7 @@ inline void StrTerminate(char (&str)[N])
 };
 
 template <size_t N>
-inline void StrCopy(char(&dst)[N], const char *src)
+inline void StrCopy(char(&dst)[N], char *src)
 {
 	strncpy(src, dst, N - 1);
 	StrTerminate(dst);

--- a/bwapi/Util/Source/Util/Convenience.h
+++ b/bwapi/Util/Source/Util/Convenience.h
@@ -19,9 +19,9 @@ inline void StrTerminate(char (&str)[N])
 };
 
 template <size_t N>
-inline void StrCopy(char(&dst)[N], char *src)
+inline void StrCopy(char(&dst)[N], const char *src)
 {
-	strncpy(src, dst, N - 1);
+	strncpy(dst, src, N - 1);
 	StrTerminate(dst);
 };
 

--- a/bwapi/Util/Source/Util/Convenience.h
+++ b/bwapi/Util/Source/Util/Convenience.h
@@ -19,16 +19,29 @@ inline void StrTerminate(char (&str)[N])
 };
 
 template <size_t N>
-inline void StrCopy(char (&dst)[N], const char *src)
+inline void StrCopy(char(&dst)[N], const char *src, int length = -1)
 {
-  strncpy(dst, src, N-1);
+  if (length == -1)
+  {
+	length = 0;
+ 	while (src[length] != '\0' &&
+		length < N)
+	{
+	  ++length;
+	}
+  }
+  else if (length > N)
+  {
+	length = N;
+  }
+  std::copy(src, src + length, dst);
   StrTerminate(dst);
 };
 
 template <size_t N>
-inline void StrCopy(char (&dst)[N], const std::string &src)
+inline void StrCopy(char(&dst)[N], const std::string &src)
 {
-  StrCopy(dst, src.c_str());
+	StrCopy(dst, src.c_str(), src.length());
 };
 
 

--- a/bwapi/Util/Source/Util/Convenience.h
+++ b/bwapi/Util/Source/Util/Convenience.h
@@ -19,29 +19,16 @@ inline void StrTerminate(char (&str)[N])
 };
 
 template <size_t N>
-inline void StrCopy(char(&dst)[N], const char *src, int length = -1)
+inline void StrCopy(char(&dst)[N], const char *src)
 {
-  if (length == -1)
-  {
-	length = 0;
- 	while (src[length] != '\0' &&
-		length < N)
-	{
-	  ++length;
-	}
-  }
-  else if (length > N)
-  {
-	length = N;
-  }
-  std::copy(src, src + length, dst);
-  StrTerminate(dst);
+	strncpy(src, dst, N - 1);
+	StrTerminate(dst);
 };
 
 template <size_t N>
 inline void StrCopy(char(&dst)[N], const std::string &src)
 {
-	StrCopy(dst, src.c_str(), src.length());
+	StrCopy(dst, src.c_str());
 };
 
 


### PR DESCRIPTION
StrCopy is currently copying the size of dst without checking if src is long enough for it. This includes a bound check.