### PR TITLE
CMakeLists to build client mode libraries + fix for VS2017

### DIFF
--- a/CMake/BWAPI/CMakeLists.txt
+++ b/CMake/BWAPI/CMakeLists.txt
@@ -1,0 +1,323 @@
+project(BWAPI-Client CXX)
+
+# Define this variable BWAPI_CUSTOM_COMPILE_FLAGS to set your compile flags
+IF(BWAPI_CUSTOM_COMPILE_FLAGS)
+    ADD_DEFINITIONS(${BWAPI_CUSTOM_COMPILE_FLAGS})
+ENDIF(BWAPI_CUSTOM_COMPILE_FLAGS)
+
+SET(BWAPI_DLL_NAME BWAPI)
+
+IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    SET(BWAPI_LIB_NAME "BWAPI-Staticd")
+    SET(CMAKE_CONFIGURATION_TYPES "Debug" CACHE STRING "" FORCE)
+ELSE()
+    SET(BWAPI_LIB_NAME "BWAPI-Static")
+    SET(CMAKE_CONFIGURATION_TYPES "Release" CACHE STRING "" FORCE)
+ENDIF()
+
+ADD_DEFINITIONS(/DNOMINMAX=1)
+
+GET_FILENAME_COMPONENT(BWAPI_ROOT ../../bwapi ABSOLUTE)
+
+SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${BWAPI_ROOT}/lib)
+SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BWAPI_ROOT}/lib)
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BWAPI_ROOT}/lib)
+
+SET(BWAPI_INCL_DIR ${BWAPI_ROOT}/include)
+INCLUDE_DIRECTORIES(
+    ${BWAPI_INCL_DIR}
+    ${BWAPI_ROOT}/Storm
+    )
+
+SET(BWAPI_INCLUDES
+    ${BWAPI_INCL_DIR}/BWAPI.h
+    ${BWAPI_INCL_DIR}/BWAPI/AIModule.h
+    ${BWAPI_INCL_DIR}/BWAPI/ArithmaticFilter.h
+    ${BWAPI_INCL_DIR}/BWAPI/BestFilter.h
+    ${BWAPI_INCL_DIR}/BWAPI/Bullet.h
+    ${BWAPI_INCL_DIR}/BWAPI/Bulletset.h
+    ${BWAPI_INCL_DIR}/BWAPI/BulletType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/BulletData.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/BulletImpl.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/Client.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/Command.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/CommandType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/Event.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/ForceData.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/ForceImpl.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/GameData.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/GameImpl.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/GameTable.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/PlayerData.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/PlayerImpl.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/RegionData.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/RegionImpl.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/Shape.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/ShapeType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/UnitCommand.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/UnitData.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client/UnitImpl.h
+    ${BWAPI_INCL_DIR}/BWAPI/Color.h
+    ${BWAPI_INCL_DIR}/BWAPI/ComparisonFilter.h
+    ${BWAPI_INCL_DIR}/BWAPI/Constants.h
+    ${BWAPI_INCL_DIR}/BWAPI/CoordinateType.h
+    ${BWAPI_INCL_DIR}/BWAPI/DamageType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Error.h
+    ${BWAPI_INCL_DIR}/BWAPI/Event.h
+    ${BWAPI_INCL_DIR}/BWAPI/EventType.h
+    ${BWAPI_INCL_DIR}/BWAPI/ExplosionType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Filters.h
+    ${BWAPI_INCL_DIR}/BWAPI/Flag.h
+    ${BWAPI_INCL_DIR}/BWAPI/Force.h
+    ${BWAPI_INCL_DIR}/BWAPI/Forceset.h
+    ${BWAPI_INCL_DIR}/BWAPI/Game.h
+    ${BWAPI_INCL_DIR}/BWAPI/GameType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Input.h
+    ${BWAPI_INCL_DIR}/BWAPI/Interface.h
+    ${BWAPI_INCL_DIR}/BWAPI/InterfaceEvent.h
+    ${BWAPI_INCL_DIR}/BWAPI/Latency.h
+    ${BWAPI_INCL_DIR}/BWAPI/Order.h
+    ${BWAPI_INCL_DIR}/BWAPI/Player.h
+    ${BWAPI_INCL_DIR}/BWAPI/Playerset.h
+    ${BWAPI_INCL_DIR}/BWAPI/PlayerType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Position.h
+    ${BWAPI_INCL_DIR}/BWAPI/PositionUnit.h
+    ${BWAPI_INCL_DIR}/BWAPI/Race.h 
+    ${BWAPI_INCL_DIR}/BWAPI/Region.h
+    ${BWAPI_INCL_DIR}/BWAPI/Regionset.h
+    ${BWAPI_INCL_DIR}/BWAPI/SetContainer.h
+    ${BWAPI_INCL_DIR}/BWAPI/TechType.h
+    ${BWAPI_INCL_DIR}/BWAPI/TournamentAction.h
+    ${BWAPI_INCL_DIR}/BWAPI/Type.h
+    ${BWAPI_INCL_DIR}/BWAPI/UnaryFilter.h
+    ${BWAPI_INCL_DIR}/BWAPI/Unit.h
+    ${BWAPI_INCL_DIR}/BWAPI/UnitCommand.h 
+    ${BWAPI_INCL_DIR}/BWAPI/UnitCommandType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Unitset.h 
+    ${BWAPI_INCL_DIR}/BWAPI/UnitSizeType.h 
+    ${BWAPI_INCL_DIR}/BWAPI/UnitType.h
+    ${BWAPI_INCL_DIR}/BWAPI/UpgradeType.h 
+    ${BWAPI_INCL_DIR}/BWAPI/WeaponType.h 
+    ${BWAPI_INCL_DIR}/BWAPI/WindowsTypes.h
+    )
+SOURCE_GROUP("BWAPI" FILES ${BWAPI_INCLUDES})
+
+SET(BWAPI_BWAPI_DIR ${BWAPI_ROOT}/BWAPI/Source)
+INCLUDE_DIRECTORIES(${BWAPI_BWAPI_DIR} ${BWAPI_BWAPI_DIR}/BWAPI)
+
+SET(BWAPI_BWAPILIB_DIR ${BWAPI_ROOT}/BWAPILib/Source)
+
+SET(BWAPI_BWAPI_SRC
+    ${BWAPI_BWAPI_DIR}/Assembly.cpp
+    ${BWAPI_BWAPI_DIR}/Assembly.h
+    ${BWAPI_BWAPI_DIR}/BW/AIController.h
+    ${BWAPI_BWAPI_DIR}/BW/Bitmap.cpp
+    ${BWAPI_BWAPI_DIR}/BW/Bitmap.h
+    ${BWAPI_BWAPI_DIR}/BW/BNETCommands.h
+    ${BWAPI_BWAPI_DIR}/BW/CBullet.h 
+    ${BWAPI_BWAPI_DIR}/BW/CheatFlags.h
+    ${BWAPI_BWAPI_DIR}/BW/CheatType.cpp
+    ${BWAPI_BWAPI_DIR}/BW/CheatType.h
+    ${BWAPI_BWAPI_DIR}/BW/CImage.cpp
+    ${BWAPI_BWAPI_DIR}/BW/CImage.h
+    ${BWAPI_BWAPI_DIR}/BW/Constants.h
+    ${BWAPI_BWAPI_DIR}/BW/COrder.h
+    ${BWAPI_BWAPI_DIR}/BW/CSprite.cpp
+    ${BWAPI_BWAPI_DIR}/BW/CSprite.h
+    ${BWAPI_BWAPI_DIR}/BW/CThingy.cpp 
+    ${BWAPI_BWAPI_DIR}/BW/CThingy.h
+    ${BWAPI_BWAPI_DIR}/BW/CUnit.cpp 
+    ${BWAPI_BWAPI_DIR}/BW/CUnit.h
+    ${BWAPI_BWAPI_DIR}/BW/Dialog.cpp
+    ${BWAPI_BWAPI_DIR}/BW/Dialog.h
+    ${BWAPI_BWAPI_DIR}/BW/FlingyID.h
+    ${BWAPI_BWAPI_DIR}/BW/Font.cpp
+    ${BWAPI_BWAPI_DIR}/BW/Font.h
+    ${BWAPI_BWAPI_DIR}/BW/GroupFlags.h
+    ${BWAPI_BWAPI_DIR}/BW/Internal.cpp
+    ${BWAPI_BWAPI_DIR}/BW/MenuPosition.h
+    ${BWAPI_BWAPI_DIR}/BW/MiniTileFlags.h
+    ${BWAPI_BWAPI_DIR}/BW/MovementFlags.h
+    ${BWAPI_BWAPI_DIR}/BW/Offsets.h
+    ${BWAPI_BWAPI_DIR}/BW/OrderFlags.h
+    ${BWAPI_BWAPI_DIR}/BW/OrderTypes.cpp
+    ${BWAPI_BWAPI_DIR}/BW/OrderTypes.h
+    ${BWAPI_BWAPI_DIR}/BW/Path.cpp 
+    ${BWAPI_BWAPI_DIR}/BW/Path.h
+    ${BWAPI_BWAPI_DIR}/BW/Pathing.cpp 
+    ${BWAPI_BWAPI_DIR}/BW/Pathing.h
+    ${BWAPI_BWAPI_DIR}/BW/PlayerID.h 
+    ${BWAPI_BWAPI_DIR}/BW/Position.h
+    ${BWAPI_BWAPI_DIR}/BW/PositionUnitTarget.cpp
+    ${BWAPI_BWAPI_DIR}/BW/PositionUnitTarget.h
+    ${BWAPI_BWAPI_DIR}/BW/Render.cpp
+    ${BWAPI_BWAPI_DIR}/BW/Render.h
+    ${BWAPI_BWAPI_DIR}/BW/Structures.h
+    ${BWAPI_BWAPI_DIR}/BW/Target.cpp
+    ${BWAPI_BWAPI_DIR}/BW/Target.h
+    ${BWAPI_BWAPI_DIR}/BW/TileSet.cpp
+    ${BWAPI_BWAPI_DIR}/BW/TileSet.h
+    ${BWAPI_BWAPI_DIR}/BW/TileType.h
+    ${BWAPI_BWAPI_DIR}/BW/TriggerEngine.cpp
+    ${BWAPI_BWAPI_DIR}/BW/TriggerEngine.h
+    ${BWAPI_BWAPI_DIR}/BW/Triggers.h
+    ${BWAPI_BWAPI_DIR}/BW/UnitPrototypeFlags.h
+    ${BWAPI_BWAPI_DIR}/BW/UnitStatusFlags.h
+    ${BWAPI_BWAPI_DIR}/BW/UnitTarget.cpp
+    ${BWAPI_BWAPI_DIR}/BW/UnitTarget.h 
+    ${BWAPI_BWAPI_DIR}/BW/WeaponTargetFlags.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/APMCounter.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/APMCounter.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/AutoMenuManager.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/AutoMenuManager.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/BulletImpl.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/BulletImpl.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/BWtoBWAPI.cpp 
+    ${BWAPI_BWAPI_DIR}/BWAPI/BWtoBWAPI.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/Command.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/CommandOptimizer.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/CommandOptimizer.h 
+    ${BWAPI_BWAPI_DIR}/BWAPI/CommandTemp.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/ForceImpl.cpp 
+    ${BWAPI_BWAPI_DIR}/BWAPI/ForceImpl.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/FPSCounter.cpp 
+    ${BWAPI_BWAPI_DIR}/BWAPI/FPSCounter.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameBullets.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameCommands.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameDrawing.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameEvents.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameImpl.cpp 
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameImpl.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameInternals.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameMenu.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameUnits.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/Map.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/Map.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/PlayerImpl.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/PlayerImpl.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/RegionImpl.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/RegionImpl.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/Server.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/Server.h 
+    ${BWAPI_BWAPI_DIR}/BWAPI/UnitImpl.cpp
+    ${BWAPI_BWAPI_DIR}/BWAPI/UnitImpl.h
+    ${BWAPI_BWAPI_DIR}/BWAPI/UnitUpdate.cpp
+    ${BWAPI_BWAPI_DIR}/CodePatch.cpp
+    ${BWAPI_BWAPI_DIR}/CodePatch.h
+    ${BWAPI_BWAPI_DIR}/Config.cpp
+    ${BWAPI_BWAPI_DIR}/Config.h
+    ${BWAPI_BWAPI_DIR}/Detours.cpp
+    ${BWAPI_BWAPI_DIR}/Detours.h
+    ${BWAPI_BWAPI_DIR}/DLLMain.cpp
+    ${BWAPI_BWAPI_DIR}/DLLMain.h
+    ${BWAPI_BWAPI_DIR}/ExceptionFilter.cpp 
+    ${BWAPI_BWAPI_DIR}/ExceptionFilter.h
+    ${BWAPI_BWAPI_DIR}/GameUpdate.cpp
+    ${BWAPI_BWAPI_DIR}/Graphics.cpp
+    ${BWAPI_BWAPI_DIR}/Graphics.h 
+    ${BWAPI_BWAPI_DIR}/NewHackUtil.cpp
+    ${BWAPI_BWAPI_DIR}/NewHackUtil.h 
+    ${BWAPI_BWAPI_DIR}/Resolution.cpp
+    ${BWAPI_BWAPI_DIR}/Resolution.h 
+    ${BWAPI_BWAPI_DIR}/Thread.cpp    
+    ${BWAPI_BWAPI_DIR}/Thread.h 
+    ${BWAPI_BWAPI_DIR}/WMode.cpp 
+    ${BWAPI_BWAPI_DIR}/WMode.h
+    ${BWAPI_BWAPILIB_DIR}/AIModule.cpp
+    ${BWAPI_BWAPILIB_DIR}/BulletType.cpp
+    ${BWAPI_BWAPILIB_DIR}/BWAPI.cpp    
+    ${BWAPI_BWAPILIB_DIR}/Color.cpp
+    ${BWAPI_BWAPILIB_DIR}/Common.h     
+    ${BWAPI_BWAPILIB_DIR}/DamageType.cpp
+    ${BWAPI_BWAPILIB_DIR}/Error.cpp       
+    ${BWAPI_BWAPILIB_DIR}/Event.cpp
+    ${BWAPI_BWAPILIB_DIR}/ExplosionType.cpp
+    ${BWAPI_BWAPILIB_DIR}/Filters.cpp
+    ${BWAPI_BWAPILIB_DIR}/Forceset.cpp    
+    ${BWAPI_BWAPILIB_DIR}/Game.cpp
+    ${BWAPI_BWAPILIB_DIR}/GameType.cpp    
+    ${BWAPI_BWAPILIB_DIR}/Order.cpp
+    ${BWAPI_BWAPILIB_DIR}/Player.cpp       
+    ${BWAPI_BWAPILIB_DIR}/Playerset.cpp
+    ${BWAPI_BWAPILIB_DIR}/PlayerType.cpp    
+    ${BWAPI_BWAPILIB_DIR}/Position.cpp
+    ${BWAPI_BWAPILIB_DIR}/PositionUnit.cpp  
+    ${BWAPI_BWAPILIB_DIR}/Race.cpp
+    ${BWAPI_BWAPILIB_DIR}/Region.cpp       
+    ${BWAPI_BWAPILIB_DIR}/Regionset.cpp
+    ${BWAPI_BWAPILIB_DIR}/TechType.cpp    
+    ${BWAPI_BWAPILIB_DIR}/Unit.cpp
+    ${BWAPI_BWAPILIB_DIR}/UnitCommandType.cpp
+    ${BWAPI_BWAPILIB_DIR}/Unitset.cpp     
+    ${BWAPI_BWAPILIB_DIR}/UnitSizeType.cpp
+    ${BWAPI_BWAPILIB_DIR}/UnitType.cpp    
+    ${BWAPI_BWAPILIB_DIR}/UpgradeType.cpp
+    ${BWAPI_BWAPILIB_DIR}/WeaponType.cpp  
+    ${BWAPI_ROOT}/BWAPILib/UnitCommand.cpp
+    )
+SOURCE_GROUP("BWAPI/BWAPI" FILES ${BWAPI_BWAPI_SRC})
+
+SET(BWAPI_UTIL_DIR ${BWAPI_ROOT}/Util/Source)
+INCLUDE_DIRECTORIES(${BWAPI_UTIL_DIR})
+SET(BWAPI_UTIL_SRC
+    ${BWAPI_ROOT}/Storm/storm.cpp
+    ${BWAPI_ROOT}/Storm/storm.h
+    ${BWAPI_UTIL_DIR}/Util/clamp.h
+    ${BWAPI_UTIL_DIR}/Util/Convenience.h
+    ${BWAPI_UTIL_DIR}/Util/Exceptions.cpp
+    ${BWAPI_UTIL_DIR}/Util/Exceptions.h
+    ${BWAPI_UTIL_DIR}/Util/MemoryFrame.cpp
+    ${BWAPI_UTIL_DIR}/Util/MemoryFrame.h
+    ${BWAPI_UTIL_DIR}/Util/Mutex.cpp
+    ${BWAPI_UTIL_DIR}/Util/Mutex.h
+    ${BWAPI_UTIL_DIR}/Util/RemoteProcess.cpp
+    ${BWAPI_UTIL_DIR}/Util/RemoteProcess.h
+    ${BWAPI_UTIL_DIR}/Util/RemoteProcessID.h
+    ${BWAPI_UTIL_DIR}/Util/sha1.cpp
+    ${BWAPI_UTIL_DIR}/Util/sha1.h
+    ${BWAPI_UTIL_DIR}/Util/SharedMemory.cpp
+    ${BWAPI_UTIL_DIR}/Util/SharedMemory.h
+    ${BWAPI_UTIL_DIR}/Util/SharedStructure.h
+    ${BWAPI_UTIL_DIR}/Util/Types.h
+    )
+SOURCE_GROUP("BWAPI/Util" FILES ${BWAPI_UTIL_SRC})
+
+SET(BWAPI_SHARED_DIR ${BWAPI_ROOT}/Shared)
+INCLUDE_DIRECTORIES(${BWAPI_SHARED_DIR})
+SET(BWAPI_SHARED_SRC
+    ${BWAPI_ROOT}/svnrev.h
+    ${BWAPI_SHARED_DIR}/BulletShared.cpp        
+    ${BWAPI_SHARED_DIR}/ForceShared.cpp
+    ${BWAPI_SHARED_DIR}/GameShared.cpp          
+    ${BWAPI_SHARED_DIR}/PlayerShared.cpp
+    ${BWAPI_SHARED_DIR}/RegionShared.cpp        
+    ${BWAPI_SHARED_DIR}/Templates.h
+    ${BWAPI_SHARED_DIR}/UnitShared.cpp
+    )
+SOURCE_GROUP("BWAPI/Shared" FILES ${BWAPI_SHARED_SRC})
+
+ADD_CUSTOM_COMMAND(OUTPUT ${BWAPI_ROOT}/svnrev.h PRE_BUILD
+        COMMAND cscript.exe ${BWAPI_ROOT}/revisionUpdate.vbs
+        WORKING_DIRECTORY ${BWAPI_ROOT})
+
+SET(BWAPI_EVERYTHING
+        ${BWAPI_BWAPI_SRC}
+        ${BWAPI_INCLUDES}
+        ${BWAPI_SHARED_SRC}
+        ${BWAPI_UTIL_SRC}
+        )
+ADD_LIBRARY(${BWAPI_LIB_NAME} STATIC ${BWAPI_EVERYTHING})
+SET_TARGET_PROPERTIES(${BWAPI_LIB_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+
+#
+#--- DLL goes here ---------------------
+# Actually it doesn't. It freezes and never starts.
+# TODO: Setting up correct compile flags
+#
+
+#ADD_DEFINITIONS(/DYNAMICBASE:NO)
+#
+#LINK_LIBRARIES(version)
+#ADD_LIBRARY(${BWAPI_DLL_NAME} SHARED ${BWAPI_EVERYTHING})
+#SET_TARGET_PROPERTIES(${BWAPI_DLL_NAME} PROPERTIES LINKER_LANGUAGE CXX)

--- a/CMake/BWAPI/CMakeLists.txt
+++ b/CMake/BWAPI/CMakeLists.txt
@@ -250,6 +250,7 @@ SET(BWAPI_BWAPI_SRC
     ${BWAPI_BWAPILIB_DIR}/UnitSizeType.cpp
     ${BWAPI_BWAPILIB_DIR}/UnitType.cpp
     ${BWAPI_BWAPILIB_DIR}/UpgradeType.cpp
+    ${BWAPI_BWAPILIB_DIR}/WeaponType.cpp
     ${BWAPI_ROOT}/BWAPICore/APMCounter.cpp
     ${BWAPI_ROOT}/BWAPICore/APMCounter.h
     ${BWAPI_ROOT}/BWAPICore/FPSCounter.cpp

--- a/CMake/BWAPI/CMakeLists.txt
+++ b/CMake/BWAPI/CMakeLists.txt
@@ -26,17 +26,12 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BWAPI_ROOT}/lib)
 SET(BWAPI_INCL_DIR ${BWAPI_ROOT}/include)
 INCLUDE_DIRECTORIES(
     ${BWAPI_INCL_DIR}
+    ${BWAPI_ROOT}/BWAPICore
     ${BWAPI_ROOT}/Storm
     )
 
 SET(BWAPI_INCLUDES
     ${BWAPI_INCL_DIR}/BWAPI.h
-    ${BWAPI_INCL_DIR}/BWAPI/AIModule.h
-    ${BWAPI_INCL_DIR}/BWAPI/ArithmaticFilter.h
-    ${BWAPI_INCL_DIR}/BWAPI/BestFilter.h
-    ${BWAPI_INCL_DIR}/BWAPI/Bullet.h
-    ${BWAPI_INCL_DIR}/BWAPI/Bulletset.h
-    ${BWAPI_INCL_DIR}/BWAPI/BulletType.h
     ${BWAPI_INCL_DIR}/BWAPI/Client.h
     ${BWAPI_INCL_DIR}/BWAPI/Client/BulletData.h
     ${BWAPI_INCL_DIR}/BWAPI/Client/BulletImpl.h
@@ -58,6 +53,14 @@ SET(BWAPI_INCLUDES
     ${BWAPI_INCL_DIR}/BWAPI/Client/UnitCommand.h
     ${BWAPI_INCL_DIR}/BWAPI/Client/UnitData.h
     ${BWAPI_INCL_DIR}/BWAPI/Client/UnitImpl.h
+    ${BWAPI_INCL_DIR}/BWAPI/AIModule.h
+    ${BWAPI_INCL_DIR}/BWAPI/ArithmaticFilter.h
+    ${BWAPI_INCL_DIR}/BWAPI/BestFilter.h
+    ${BWAPI_INCL_DIR}/BWAPI/BroodwarOutputDevice.h
+    ${BWAPI_INCL_DIR}/BWAPI/Bullet.h
+    ${BWAPI_INCL_DIR}/BWAPI/Bulletset.h
+    ${BWAPI_INCL_DIR}/BWAPI/BulletType.h
+    ${BWAPI_INCL_DIR}/BWAPI/Client.h
     ${BWAPI_INCL_DIR}/BWAPI/Color.h
     ${BWAPI_INCL_DIR}/BWAPI/ComparisonFilter.h
     ${BWAPI_INCL_DIR}/BWAPI/Constants.h
@@ -82,24 +85,22 @@ SET(BWAPI_INCLUDES
     ${BWAPI_INCL_DIR}/BWAPI/Playerset.h
     ${BWAPI_INCL_DIR}/BWAPI/PlayerType.h
     ${BWAPI_INCL_DIR}/BWAPI/Position.h
-    ${BWAPI_INCL_DIR}/BWAPI/PositionUnit.h
-    ${BWAPI_INCL_DIR}/BWAPI/Race.h 
+    ${BWAPI_INCL_DIR}/BWAPI/Race.h
     ${BWAPI_INCL_DIR}/BWAPI/Region.h
     ${BWAPI_INCL_DIR}/BWAPI/Regionset.h
     ${BWAPI_INCL_DIR}/BWAPI/SetContainer.h
+    ${BWAPI_INCL_DIR}/BWAPI/Streams.h
     ${BWAPI_INCL_DIR}/BWAPI/TechType.h
     ${BWAPI_INCL_DIR}/BWAPI/TournamentAction.h
     ${BWAPI_INCL_DIR}/BWAPI/Type.h
     ${BWAPI_INCL_DIR}/BWAPI/UnaryFilter.h
     ${BWAPI_INCL_DIR}/BWAPI/Unit.h
-    ${BWAPI_INCL_DIR}/BWAPI/UnitCommand.h 
+    ${BWAPI_INCL_DIR}/BWAPI/UnitCommand.h
     ${BWAPI_INCL_DIR}/BWAPI/UnitCommandType.h
-    ${BWAPI_INCL_DIR}/BWAPI/Unitset.h 
-    ${BWAPI_INCL_DIR}/BWAPI/UnitSizeType.h 
+    ${BWAPI_INCL_DIR}/BWAPI/Unitset.h
+    ${BWAPI_INCL_DIR}/BWAPI/UnitSizeType.h
     ${BWAPI_INCL_DIR}/BWAPI/UnitType.h
-    ${BWAPI_INCL_DIR}/BWAPI/UpgradeType.h 
-    ${BWAPI_INCL_DIR}/BWAPI/WeaponType.h 
-    ${BWAPI_INCL_DIR}/BWAPI/WindowsTypes.h
+    ${BWAPI_INCL_DIR}/BWAPI/UpgradeType.h
     )
 SOURCE_GROUP("BWAPI" FILES ${BWAPI_INCLUDES})
 
@@ -167,27 +168,23 @@ SET(BWAPI_BWAPI_SRC
     ${BWAPI_BWAPI_DIR}/BW/UnitTarget.cpp
     ${BWAPI_BWAPI_DIR}/BW/UnitTarget.h 
     ${BWAPI_BWAPI_DIR}/BW/WeaponTargetFlags.h
-    ${BWAPI_BWAPI_DIR}/BWAPI/APMCounter.cpp
-    ${BWAPI_BWAPI_DIR}/BWAPI/APMCounter.h
     ${BWAPI_BWAPI_DIR}/BWAPI/AutoMenuManager.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/AutoMenuManager.h
     ${BWAPI_BWAPI_DIR}/BWAPI/BulletImpl.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/BulletImpl.h
-    ${BWAPI_BWAPI_DIR}/BWAPI/BWtoBWAPI.cpp 
+    ${BWAPI_BWAPI_DIR}/BWAPI/BWtoBWAPI.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/BWtoBWAPI.h
     ${BWAPI_BWAPI_DIR}/BWAPI/Command.h
     ${BWAPI_BWAPI_DIR}/BWAPI/CommandOptimizer.cpp
-    ${BWAPI_BWAPI_DIR}/BWAPI/CommandOptimizer.h 
+    ${BWAPI_BWAPI_DIR}/BWAPI/CommandOptimizer.h
     ${BWAPI_BWAPI_DIR}/BWAPI/CommandTemp.h
-    ${BWAPI_BWAPI_DIR}/BWAPI/ForceImpl.cpp 
+    ${BWAPI_BWAPI_DIR}/BWAPI/ForceImpl.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/ForceImpl.h
-    ${BWAPI_BWAPI_DIR}/BWAPI/FPSCounter.cpp 
-    ${BWAPI_BWAPI_DIR}/BWAPI/FPSCounter.h
     ${BWAPI_BWAPI_DIR}/BWAPI/GameBullets.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/GameCommands.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/GameDrawing.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/GameEvents.cpp
-    ${BWAPI_BWAPI_DIR}/BWAPI/GameImpl.cpp 
+    ${BWAPI_BWAPI_DIR}/BWAPI/GameImpl.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/GameImpl.h
     ${BWAPI_BWAPI_DIR}/BWAPI/GameInternals.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/GameMenu.cpp
@@ -199,7 +196,7 @@ SET(BWAPI_BWAPI_SRC
     ${BWAPI_BWAPI_DIR}/BWAPI/RegionImpl.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/RegionImpl.h
     ${BWAPI_BWAPI_DIR}/BWAPI/Server.cpp
-    ${BWAPI_BWAPI_DIR}/BWAPI/Server.h 
+    ${BWAPI_BWAPI_DIR}/BWAPI/Server.h
     ${BWAPI_BWAPI_DIR}/BWAPI/UnitImpl.cpp
     ${BWAPI_BWAPI_DIR}/BWAPI/UnitImpl.h
     ${BWAPI_BWAPI_DIR}/BWAPI/UnitUpdate.cpp
@@ -211,49 +208,52 @@ SET(BWAPI_BWAPI_SRC
     ${BWAPI_BWAPI_DIR}/Detours.h
     ${BWAPI_BWAPI_DIR}/DLLMain.cpp
     ${BWAPI_BWAPI_DIR}/DLLMain.h
-    ${BWAPI_BWAPI_DIR}/ExceptionFilter.cpp 
+    ${BWAPI_BWAPI_DIR}/ExceptionFilter.cpp
     ${BWAPI_BWAPI_DIR}/ExceptionFilter.h
     ${BWAPI_BWAPI_DIR}/GameUpdate.cpp
     ${BWAPI_BWAPI_DIR}/Graphics.cpp
-    ${BWAPI_BWAPI_DIR}/Graphics.h 
+    ${BWAPI_BWAPI_DIR}/Graphics.h
     ${BWAPI_BWAPI_DIR}/NewHackUtil.cpp
-    ${BWAPI_BWAPI_DIR}/NewHackUtil.h 
+    ${BWAPI_BWAPI_DIR}/NewHackUtil.h
     ${BWAPI_BWAPI_DIR}/Resolution.cpp
-    ${BWAPI_BWAPI_DIR}/Resolution.h 
-    ${BWAPI_BWAPI_DIR}/Thread.cpp    
-    ${BWAPI_BWAPI_DIR}/Thread.h 
-    ${BWAPI_BWAPI_DIR}/WMode.cpp 
+    ${BWAPI_BWAPI_DIR}/Resolution.h
+    ${BWAPI_BWAPI_DIR}/Thread.cpp
+    ${BWAPI_BWAPI_DIR}/Thread.h
+    ${BWAPI_BWAPI_DIR}/WMode.cpp
     ${BWAPI_BWAPI_DIR}/WMode.h
     ${BWAPI_BWAPILIB_DIR}/AIModule.cpp
+    ${BWAPI_BWAPILIB_DIR}/BroodwarOutputDevice.cpp
     ${BWAPI_BWAPILIB_DIR}/BulletType.cpp
-    ${BWAPI_BWAPILIB_DIR}/BWAPI.cpp    
+    ${BWAPI_BWAPILIB_DIR}/BWAPI.cpp
     ${BWAPI_BWAPILIB_DIR}/Color.cpp
-    ${BWAPI_BWAPILIB_DIR}/Common.h     
     ${BWAPI_BWAPILIB_DIR}/DamageType.cpp
-    ${BWAPI_BWAPILIB_DIR}/Error.cpp       
+    ${BWAPI_BWAPILIB_DIR}/Error.cpp
     ${BWAPI_BWAPILIB_DIR}/Event.cpp
     ${BWAPI_BWAPILIB_DIR}/ExplosionType.cpp
     ${BWAPI_BWAPILIB_DIR}/Filters.cpp
-    ${BWAPI_BWAPILIB_DIR}/Forceset.cpp    
+    ${BWAPI_BWAPILIB_DIR}/Forceset.cpp
     ${BWAPI_BWAPILIB_DIR}/Game.cpp
-    ${BWAPI_BWAPILIB_DIR}/GameType.cpp    
+    ${BWAPI_BWAPILIB_DIR}/GameType.cpp
     ${BWAPI_BWAPILIB_DIR}/Order.cpp
-    ${BWAPI_BWAPILIB_DIR}/Player.cpp       
+    ${BWAPI_BWAPILIB_DIR}/Player.cpp
     ${BWAPI_BWAPILIB_DIR}/Playerset.cpp
-    ${BWAPI_BWAPILIB_DIR}/PlayerType.cpp    
+    ${BWAPI_BWAPILIB_DIR}/PlayerType.cpp
     ${BWAPI_BWAPILIB_DIR}/Position.cpp
-    ${BWAPI_BWAPILIB_DIR}/PositionUnit.cpp  
     ${BWAPI_BWAPILIB_DIR}/Race.cpp
-    ${BWAPI_BWAPILIB_DIR}/Region.cpp       
+    ${BWAPI_BWAPILIB_DIR}/Region.cpp
     ${BWAPI_BWAPILIB_DIR}/Regionset.cpp
-    ${BWAPI_BWAPILIB_DIR}/TechType.cpp    
+    ${BWAPI_BWAPILIB_DIR}/Streams.cpp
+    ${BWAPI_BWAPILIB_DIR}/TechType.cpp
     ${BWAPI_BWAPILIB_DIR}/Unit.cpp
     ${BWAPI_BWAPILIB_DIR}/UnitCommandType.cpp
-    ${BWAPI_BWAPILIB_DIR}/Unitset.cpp     
+    ${BWAPI_BWAPILIB_DIR}/Unitset.cpp
     ${BWAPI_BWAPILIB_DIR}/UnitSizeType.cpp
-    ${BWAPI_BWAPILIB_DIR}/UnitType.cpp    
+    ${BWAPI_BWAPILIB_DIR}/UnitType.cpp
     ${BWAPI_BWAPILIB_DIR}/UpgradeType.cpp
-    ${BWAPI_BWAPILIB_DIR}/WeaponType.cpp  
+    ${BWAPI_ROOT}/BWAPICore/APMCounter.cpp
+    ${BWAPI_ROOT}/BWAPICore/APMCounter.h
+    ${BWAPI_ROOT}/BWAPICore/FPSCounter.cpp
+    ${BWAPI_ROOT}/BWAPICore/FPSCounter.h
     ${BWAPI_ROOT}/BWAPILib/UnitCommand.cpp
     )
 SOURCE_GROUP("BWAPI/BWAPI" FILES ${BWAPI_BWAPI_SRC})
@@ -263,7 +263,7 @@ INCLUDE_DIRECTORIES(${BWAPI_UTIL_DIR})
 SET(BWAPI_UTIL_SRC
     ${BWAPI_ROOT}/Storm/storm.cpp
     ${BWAPI_ROOT}/Storm/storm.h
-    ${BWAPI_UTIL_DIR}/Util/clamp.h
+    ${BWAPI_UTIL_DIR}/Util/Clamp.h
     ${BWAPI_UTIL_DIR}/Util/Convenience.h
     ${BWAPI_UTIL_DIR}/Util/Exceptions.cpp
     ${BWAPI_UTIL_DIR}/Util/Exceptions.h
@@ -271,6 +271,7 @@ SET(BWAPI_UTIL_SRC
     ${BWAPI_UTIL_DIR}/Util/MemoryFrame.h
     ${BWAPI_UTIL_DIR}/Util/Mutex.cpp
     ${BWAPI_UTIL_DIR}/Util/Mutex.h
+    ${BWAPI_UTIL_DIR}/Util/Path.h
     ${BWAPI_UTIL_DIR}/Util/RemoteProcess.cpp
     ${BWAPI_UTIL_DIR}/Util/RemoteProcess.h
     ${BWAPI_UTIL_DIR}/Util/RemoteProcessID.h
@@ -279,6 +280,7 @@ SET(BWAPI_UTIL_SRC
     ${BWAPI_UTIL_DIR}/Util/SharedMemory.cpp
     ${BWAPI_UTIL_DIR}/Util/SharedMemory.h
     ${BWAPI_UTIL_DIR}/Util/SharedStructure.h
+    ${BWAPI_UTIL_DIR}/Util/StringUtil.h
     ${BWAPI_UTIL_DIR}/Util/Types.h
     )
 SOURCE_GROUP("BWAPI/Util" FILES ${BWAPI_UTIL_SRC})

--- a/CMake/Client/CMakeLists.txt
+++ b/CMake/Client/CMakeLists.txt
@@ -48,7 +48,7 @@ INCLUDE_DIRECTORIES(${BWAPI_UTIL_DIR})
 SET(BWAPI_UTIL_SRC
         ${BWAPI_ROOT}/Storm/storm.cpp
         ${BWAPI_ROOT}/Storm/storm.h
-        ${BWAPI_UTIL_DIR}/Util/clamp.h
+        ${BWAPI_UTIL_DIR}/Util/Clamp.h
         ${BWAPI_UTIL_DIR}/Util/Convenience.h
         ${BWAPI_UTIL_DIR}/Util/Exceptions.cpp
         ${BWAPI_UTIL_DIR}/Util/Exceptions.h
@@ -56,6 +56,7 @@ SET(BWAPI_UTIL_SRC
         ${BWAPI_UTIL_DIR}/Util/MemoryFrame.h
         ${BWAPI_UTIL_DIR}/Util/Mutex.cpp
         ${BWAPI_UTIL_DIR}/Util/Mutex.h
+        ${BWAPI_UTIL_DIR}/Util/Path.h
         ${BWAPI_UTIL_DIR}/Util/RemoteProcess.cpp
         ${BWAPI_UTIL_DIR}/Util/RemoteProcess.h
         ${BWAPI_UTIL_DIR}/Util/RemoteProcessID.h
@@ -64,6 +65,7 @@ SET(BWAPI_UTIL_SRC
         ${BWAPI_UTIL_DIR}/Util/SharedMemory.cpp
         ${BWAPI_UTIL_DIR}/Util/SharedMemory.h
         ${BWAPI_UTIL_DIR}/Util/SharedStructure.h
+        ${BWAPI_UTIL_DIR}/Util/StringUtil.h
         ${BWAPI_UTIL_DIR}/Util/Types.h
         )
 SOURCE_GROUP("BWAPI/Util" FILES ${BWAPI_UTIL_SRC})

--- a/CMake/Client/CMakeLists.txt
+++ b/CMake/Client/CMakeLists.txt
@@ -1,0 +1,89 @@
+project(BWAPI-Client CXX)
+
+# Define this variable BWAPI_CUSTOM_COMPILE_FLAGS to set your compile flags
+IF(BWAPI_CUSTOM_COMPILE_FLAGS)
+    ADD_DEFINITIONS(${BWAPI_CUSTOM_COMPILE_FLAGS})
+ENDIF(BWAPI_CUSTOM_COMPILE_FLAGS)
+
+IF (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    SET(BWAPICLIENT_LIB_NAME BWAPIClientd)
+    SET(CMAKE_CONFIGURATION_TYPES "Debug" CACHE STRING "" FORCE)
+ELSE ()
+    SET(BWAPICLIENT_LIB_NAME BWAPIClient)
+    SET(CMAKE_CONFIGURATION_TYPES "Release" CACHE STRING "" FORCE)
+ENDIF ()
+
+ADD_DEFINITIONS(/DNOMINMAX=1)
+
+GET_FILENAME_COMPONENT(BWAPI_ROOT ../../bwapi ABSOLUTE)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${BWAPI_ROOT}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BWAPI_ROOT}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BWAPI_ROOT}/lib)
+
+SET(BWAPI_INCL_DIR ${BWAPI_ROOT}/include)
+INCLUDE_DIRECTORIES(
+        ${BWAPI_INCL_DIR}
+        ${BWAPI_INCL_DIR}/BWAPI/Client
+        ${BWAPI_ROOT}/Storm
+        )
+
+SET(BWAPI_CLIENT_DIR ${BWAPI_ROOT}/BWAPIClient/Source)
+INCLUDE_DIRECTORIES(${BWAPI_CLIENT_DIR})
+SET(BWAPI_CLIENT_SRC
+        ${BWAPI_CLIENT_DIR}/BulletImpl.cpp
+        ${BWAPI_CLIENT_DIR}/Client.cpp
+        ${BWAPI_CLIENT_DIR}/Command.h
+        ${BWAPI_CLIENT_DIR}/Convenience.h
+        ${BWAPI_CLIENT_DIR}/ForceImpl.cpp
+        ${BWAPI_CLIENT_DIR}/GameImpl.cpp
+        ${BWAPI_CLIENT_DIR}/PlayerImpl.cpp
+        ${BWAPI_CLIENT_DIR}/RegionImpl.cpp
+        ${BWAPI_CLIENT_DIR}/UnitImpl.cpp
+        )
+SOURCE_GROUP("BWAPI/Client" FILES ${BWAPI_CLIENT_SRC})
+
+SET(BWAPI_UTIL_DIR ${BWAPI_ROOT}/Util/Source)
+INCLUDE_DIRECTORIES(${BWAPI_UTIL_DIR})
+SET(BWAPI_UTIL_SRC
+        ${BWAPI_ROOT}/Storm/storm.cpp
+        ${BWAPI_ROOT}/Storm/storm.h
+        ${BWAPI_UTIL_DIR}/Util/clamp.h
+        ${BWAPI_UTIL_DIR}/Util/Convenience.h
+        ${BWAPI_UTIL_DIR}/Util/Exceptions.cpp
+        ${BWAPI_UTIL_DIR}/Util/Exceptions.h
+        ${BWAPI_UTIL_DIR}/Util/MemoryFrame.cpp
+        ${BWAPI_UTIL_DIR}/Util/MemoryFrame.h
+        ${BWAPI_UTIL_DIR}/Util/Mutex.cpp
+        ${BWAPI_UTIL_DIR}/Util/Mutex.h
+        ${BWAPI_UTIL_DIR}/Util/RemoteProcess.cpp
+        ${BWAPI_UTIL_DIR}/Util/RemoteProcess.h
+        ${BWAPI_UTIL_DIR}/Util/RemoteProcessID.h
+        ${BWAPI_UTIL_DIR}/Util/sha1.cpp
+        ${BWAPI_UTIL_DIR}/Util/sha1.h
+        ${BWAPI_UTIL_DIR}/Util/SharedMemory.cpp
+        ${BWAPI_UTIL_DIR}/Util/SharedMemory.h
+        ${BWAPI_UTIL_DIR}/Util/SharedStructure.h
+        ${BWAPI_UTIL_DIR}/Util/Types.h
+        )
+SOURCE_GROUP("BWAPI/Util" FILES ${BWAPI_UTIL_SRC})
+
+SET(BWAPI_SHARED_DIR ${BWAPI_ROOT}/Shared)
+INCLUDE_DIRECTORIES(${BWAPI_SHARED_DIR})
+SET(BWAPI_SHARED_SRC
+        ${BWAPI_SHARED_DIR}/BulletShared.cpp
+        ${BWAPI_SHARED_DIR}/ForceShared.cpp
+        ${BWAPI_SHARED_DIR}/GameShared.cpp
+        ${BWAPI_SHARED_DIR}/PlayerShared.cpp
+        ${BWAPI_SHARED_DIR}/RegionShared.cpp
+        ${BWAPI_SHARED_DIR}/Templates.h
+        ${BWAPI_SHARED_DIR}/UnitShared.cpp
+        )
+SOURCE_GROUP("BWAPI/Shared" FILES ${BWAPI_SHARED_SRC})
+
+ADD_LIBRARY(${BWAPICLIENT_LIB_NAME} STATIC
+        ${BWAPI_CLIENT_SRC}
+        ${BWAPI_UTIL_SRC}
+        ${BWAPI_SHARED_SRC}
+        )
+SET_TARGET_PROPERTIES(${BWAPICLIENT_LIB_NAME} PROPERTIES LINKER_LANGUAGE CXX)

--- a/CMake/README.md
+++ b/CMake/README.md
@@ -1,0 +1,39 @@
+# CMake support for BWAPI-Client
+
+This is CMake project which can be included in your bot application. 
+**NOTE** You get two static libraries. 
+They are not usable for DLL bots.
+
+These two libraries can only be linked with your client-mode bot (see
+`bwapi/ExampleAIClient` for an example).
+
+## Why?
+
+This project does not require VS2013, and can be built with other compilers,
+such as VS2015, VS2017 and, potentially, GCC with C++17 enabled.
+
+## How to use?
+
+In your `CMakeLists.txt` add a line **before** your `PROJECT(...)`:
+
+    ADD_SUBDIRECTORY(${MY_PATH_TO_BWAPI}/CMake/BWAPI/)
+    ADD_SUBDIRECTORY(${MY_PATH_TO_BWAPI}/CMake/Client/)
+
+In your `CMakeLists.txt` add lines **inside** your `PROJECT(...)`:
+
+    GET_FILENAME_COMPONENT(BWAPI_ROOT ${CMAKE_SOURCE_DIR}/deps/bwapi/bwapi ABSOLUTE)
+    INCLUDE_DIRECTORIES(${BWAPI_ROOT}/include ${BWAPI_ROOT}/Util/Source)
+
+And in linker section add lines:
+
+    ADD_DEPENDENCIES(YourProject BWAPI-Staticd)
+    ADD_DEPENDENCIES(YourProject BWAPIClientd)
+
+If you build as release, remove `d` and use `BWAPI` and `BWAPIClient` instead.
+
+## Custom compile flags
+
+It may happen so, that your project uses different compile flags than those,
+selected by default in these BWAPI projects. In such case set the 
+variable `BWAPI_CUSTOM_COMPILE_FLAGS` to contain compile flags before you
+include CMake subdirectories.

--- a/bwapi/BWAPI/Source/BW/Bitmap.cpp
+++ b/bwapi/BWAPI/Source/BW/Bitmap.cpp
@@ -1,6 +1,6 @@
 #include "Bitmap.h"
 #include <storm.h>
-#include <boost/algorithm/clamp.hpp>
+#include <Util/clamp.h>
 #include <algorithm>
 
 #include "Font.h"
@@ -9,8 +9,6 @@
 
 namespace BW
 {
-  using boost::algorithm::clamp;
-
   Bitmap::Bitmap(int width, int height, void *pBuffer)
     : wid(static_cast<u16>(width))
     , ht(static_cast<u16>(height))
@@ -315,8 +313,8 @@ namespace BW
     // If the line is completely vertical or horizontal
     if ( x1 == x2 )
     {
-      int ymin = clamp(std::min(y1,y2), 0, this->height()-1);
-      int ymax = clamp(std::max(y1,y2), 0, this->height()-1);
+      int ymin = Util::clamp(std::min(y1,y2), 0, this->height()-1);
+      int ymax = Util::clamp(std::max(y1,y2), 0, this->height()-1);
 
       // Plot vertical line
       for ( int i = ymin; i < ymax; ++i )
@@ -325,8 +323,8 @@ namespace BW
     }
     else if ( y1 == y2 )
     {
-      int xmin = clamp(std::min(x1,x2), 0, this->width()-1);
-      int xmax = clamp(std::max(x1,x2), 0, this->width()-1);
+      int xmin = Util::clamp(std::min(x1,x2), 0, this->width()-1);
+      int xmax = Util::clamp(std::max(x1,x2), 0, this->width()-1);
 
       // Plot horizontal line
       memset(&this->data[y1 * this->width() + xmin], color, xmax - xmin );

--- a/bwapi/BWAPI/Source/BW/Bitmap.cpp
+++ b/bwapi/BWAPI/Source/BW/Bitmap.cpp
@@ -1,6 +1,6 @@
 #include "Bitmap.h"
 #include <storm.h>
-#include <Util/clamp.h>
+#include <Util/Clamp.h>
 #include <algorithm>
 
 #include "Font.h"

--- a/bwapi/BWAPI/Source/BW/CheatType.cpp
+++ b/bwapi/BWAPI/Source/BW/CheatType.cpp
@@ -1,13 +1,13 @@
 #include "CheatType.h"
 #include <string>
-#include <boost/algorithm/string.hpp>
+#include <Util/StringUtil.h>
 
 namespace BW
 {
   CheatFlags::Enum getCheatFlag(const std::string &str)
   {
     // Convert to lowercase in a new string
-    std::string name = boost::to_lower_copy(str);
+    std::string name = Util::to_lower_copy(str);
 
     // Get the cheat flag
     if      ( name == "black sheep wall" )            return CheatFlags::BlackSheepWall;

--- a/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/AutoMenuManager.cpp
@@ -4,8 +4,8 @@
 
 #include <algorithm>
 #include <sstream>
-#include <boost/filesystem.hpp>
-#include <boost/algorithm/string/trim.hpp>
+#include <Util/Path.h>
+#include <Util/StringUtil.h>
 
 #include <BW/MenuPosition.h>
 #include <BW/Dialog.h>
@@ -110,8 +110,8 @@ void AutoMenuManager::reloadConfig()
       std::getline(raceList, currentrace, ',');
 
   // trim whitespace outside quotations and then the quotations
-  boost::trim(currentrace);
-  boost::trim_if(currentrace, boost::is_any_of("\""));
+  Util::trim(currentrace, Util::is_whitespace_or_newline);
+  Util::trim(currentrace, [](char c) { return c == '"'; });
 
   this->autoMenuRace = currentrace;
 
@@ -495,7 +495,7 @@ const char* AutoMenuManager::interceptFindFirstFile(const char* lpFileName)
     lpFileName = lastMapGen.c_str();
 
     // Get the directory that the map is in
-    std::string directoryPath = boost::filesystem::path(installPath() + lastMapGen).parent_path().string();
+    std::string directoryPath = Util::Path(installPath() + lastMapGen).parent_path().string();
 
     // update map folder location
     SStrCopy(BW::BWDATA::CurrentMapFolder.data(), directoryPath.c_str(), MAX_PATH);

--- a/bwapi/BWAPI/Source/BWAPI/GameDrawing.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameDrawing.cpp
@@ -2,7 +2,7 @@
 
 #include "../Graphics.h"
 #include <cassert>
-#include <boost/algorithm/clamp.hpp>
+#include <Util/clamp.h>
 #include <Util/Convenience.h>
 
 #include <BW/Dialog.h>
@@ -140,7 +140,7 @@ namespace BWAPI
   void GameImpl::setTextSize(Text::Size::Enum size)
   {
     // Clamp to valid sizes
-    size = boost::algorithm::clamp(size, Text::Size::Small, Text::Size::Huge);
+    size = Util::clamp(size, Text::Size::Small, Text::Size::Huge);
 
     if ( !this->tournamentCheck(Tournament::SetTextSize, &size) )
       return;

--- a/bwapi/BWAPI/Source/BWAPI/GameDrawing.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameDrawing.cpp
@@ -2,7 +2,7 @@
 
 #include "../Graphics.h"
 #include <cassert>
-#include <Util/clamp.h>
+#include <Util/Clamp.h>
 #include <Util/Convenience.h>
 
 #include <BW/Dialog.h>

--- a/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
@@ -2,6 +2,7 @@
 #include <ctime>
 
 #include <Util/Path.h>
+#include <Util/StringUtil.h>
 
 #include "Detours.h"
 
@@ -13,7 +14,6 @@
 
 #include "../../../svnrev.h"
 #include "../../../Debug.h"
-#include "Util/StringUtil.h"
 
 namespace BWAPI
 {

--- a/bwapi/BWAPI/Source/BWAPI/GameImpl.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameImpl.cpp
@@ -8,7 +8,7 @@
 #include <cmath>
 #include <fstream>
 
-#include <boost/algorithm/clamp.hpp>
+#include <Util/clamp.h>
 #include <Util/Convenience.h>
 
 #include <BWAPI/ForceImpl.h>
@@ -788,7 +788,7 @@ namespace BWAPI
       caps.dwSize = sizeof(CAPS);
       SNetGetProviderCaps(&caps);
 
-      dwCallDelay = boost::algorithm::clamp(caps.dwCallDelay, 2, 8);
+      dwCallDelay = Util::clamp<int>(caps.dwCallDelay, 2, 8);
     }
     return (BW::BWDATA::LatencyFrames[BW::BWDATA::GameSpeed]) * (BW::BWDATA::Latency + dwCallDelay + 1);
   }
@@ -862,7 +862,7 @@ namespace BWAPI
   //-------------------------------------- SET COMMAND OPTIMIZATION LEVEL ------------------------------------
   void GameImpl::setCommandOptimizationLevel(int level)
   {
-    level = boost::algorithm::clamp(level, 0, 4);
+    level = Util::clamp(level, 0, 4);
     if ( !this->tournamentCheck(Tournament::SetCommandOptimizationLevel, &level) )
       return;
     this->commandOptimizer.level = level;

--- a/bwapi/BWAPI/Source/BWAPI/GameImpl.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameImpl.cpp
@@ -8,7 +8,7 @@
 #include <cmath>
 #include <fstream>
 
-#include <Util/clamp.h>
+#include <Util/Clamp.h>
 #include <Util/Convenience.h>
 
 #include <BWAPI/ForceImpl.h>

--- a/bwapi/BWAPI/Source/BWAPI/GameMenu.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameMenu.cpp
@@ -10,7 +10,7 @@
 #include <BW/MenuPosition.h>
 #include <BW/Dialog.h>
 #include <BW/OrderTypes.h>
-#include <boost/algorithm/clamp.hpp>
+#include <Util/Clamp.h>
 
 #include "../../../Debug.h"
 
@@ -65,7 +65,7 @@ namespace BWAPI
     BW::dialog *custom = BW::FindDialogGlobal("Create");
     if ( custom )
     {
-      slot = boost::algorithm::clamp(slot, 0, 7);
+      slot = Util::clamp(slot, 0, 7);
       // Apply the single player change
       BW::dialog *slotCtrl = custom->findIndex((short)(28 + slot));  // 28 is the CtrlID of the first slot
       if ( slotCtrl && (int)slotCtrl->getSelectedValue() != race )

--- a/bwapi/BWAPI/Source/BWAPI/Map.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/Map.cpp
@@ -4,8 +4,7 @@
 #include <memory>
 #include <Util/Sha1.h>
 
-#include <boost/filesystem.hpp>
-#include <boost/algorithm/string.hpp>
+#include <Util/Path.h>
 
 #include "../DLLMain.h"
 #include "../Config.h"
@@ -36,13 +35,17 @@ namespace BWAPI
   std::string Map::getPathName()
   {
     std::string mapPath( BW::BWDATA::Game.mapFileName );
-    boost::erase_first(mapPath, installPath());     // Remove the install path to create a relative path
+
+    // If the install path is included in the map path, remove it, creating a relative path
+    if (!installPath().empty() && mapPath.compare(0, installPath().length(), installPath()) == 0)
+      mapPath.erase(0, installPath().length());
+
     return mapPath;
   }
   //---------------------------------------------- GET FILE NAME ---------------------------------------------
   std::string Map::getFileName()
   {
-    boost::filesystem::path mapPath( BW::BWDATA::Game.mapFileName );
+    Util::Path mapPath( BW::BWDATA::Game.mapFileName );
     return mapPath.filename().string();
   }
   //------------------------------------------------ GET NAME ------------------------------------------------

--- a/bwapi/BWAPI/Source/Config.cpp
+++ b/bwapi/BWAPI/Source/Config.cpp
@@ -3,7 +3,7 @@
 #include <tlhelp32.h>
 #include <storm.h>
 
-#include <boost/algorithm/string.hpp>
+#include <Util/StringUtil.h>
 
 #include "Config.h"
 
@@ -41,7 +41,7 @@ DWORD getProcessCount(const char *pszProcName)
 //----------------------------- LOAD CONFIG FXNS ------------------------------------------
 std::string envKeyName(const char *pszKey, const char *pszItem)
 {
-  return "BWAPI_CONFIG_" + boost::to_upper_copy(std::string(pszKey)) + "__" + boost::to_upper_copy(std::string(pszItem));
+  return "BWAPI_CONFIG_" + Util::to_upper_copy(pszKey) + "__" + Util::to_upper_copy(pszItem);
 }
 std::string LoadConfigStringFromFile(const char *pszKey, const char *pszItem, const char *pszDefault)
 {
@@ -60,7 +60,7 @@ std::string LoadConfigString(const char *pszKey, const char *pszItem, const char
 // this version uppercase result string after loading, should be used for the most of enum-like strings
 std::string LoadConfigStringUCase (const char *pszKey, const char *pszItem, const char *pszDefault)
 {
-  return boost::to_upper_copy(LoadConfigString(pszKey, pszItem, pszDefault));
+  return Util::to_upper_copy(LoadConfigString(pszKey, pszItem, pszDefault));
 }
 int LoadConfigInt(const char *pszKey, const char *pszItem, const int iDefault)
 {

--- a/bwapi/BWAPI/Source/Config.h
+++ b/bwapi/BWAPI/Source/Config.h
@@ -2,7 +2,7 @@
 #include <string>
 #include <storm.h>
 #include "DLLMain.h"
-#include <boost/filesystem/path.hpp>
+#include <Util/Path.h>
 
 // Functions
 std::string LoadConfigString(const char *pszKey, const char *pszItem, const char *pszDefault = NULL);
@@ -21,7 +21,7 @@ inline const std::string& installPath()
   {
     char buffer[MAX_PATH];
     if (GetModuleFileNameA(NULL, buffer, MAX_PATH)) //get .exe path
-      path = boost::filesystem::path(buffer).parent_path().string() + "\\";
+      path = Util::Path(buffer).parent_path().string() + "\\";
     else
       BWAPIError("Error getting starcraft's root directory via GetModuleFileNameA()");
   }

--- a/bwapi/BWAPI/Source/DLLMain.cpp
+++ b/bwapi/BWAPI/Source/DLLMain.cpp
@@ -5,7 +5,7 @@
 #include <cassert>
 #include "Thread.h"
 
-#include <Util/clamp.h>
+#include <Util/Clamp.h>
 #include <Util/Convenience.h>
 
 #include <BWAPI.h>

--- a/bwapi/BWAPI/Source/DLLMain.cpp
+++ b/bwapi/BWAPI/Source/DLLMain.cpp
@@ -5,7 +5,7 @@
 #include <cassert>
 #include "Thread.h"
 
-#include <boost/algorithm/clamp.hpp>
+#include <Util/clamp.h>
 #include <Util/Convenience.h>
 
 #include <BWAPI.h>
@@ -37,7 +37,7 @@ void __fastcall QueueGameCommand(void *pBuffer, size_t dwLength)
   caps.dwSize = sizeof(CAPS);
   SNetGetProviderCaps(&caps);
 
-  DWORD dwMaxBuffer = boost::algorithm::clamp(caps.maxmessagesize, 0, BW::BWDATA::TurnBuffer.size());
+  DWORD dwMaxBuffer = Util::clamp<size_t>(caps.maxmessagesize, 0, BW::BWDATA::TurnBuffer.size());
   if ( dwLength + BW::BWDATA::sgdwBytesInCmdQueue <= dwMaxBuffer )
   {
     // Copy data to primary turn buffer
@@ -55,7 +55,7 @@ void __fastcall QueueGameCommand(void *pBuffer, size_t dwLength)
   {
     int callDelay = 1;
     if ( BW::BWDATA::NetMode )
-      callDelay = boost::algorithm::clamp(caps.dwCallDelay, 2, 8);
+      callDelay = Util::clamp<int>(caps.dwCallDelay, 2, 8);
 
     // This statement will probably never be hit, but just in case
     if ( turns >= 16 - callDelay )

--- a/bwapi/BWAPI/Source/Detours.cpp
+++ b/bwapi/BWAPI/Source/Detours.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <storm.h>
 
-#include <boost/filesystem.hpp>
+#include <Util/Path.h>
 
 #include "WMode.h"
 #include "DLLMain.h"
@@ -299,7 +299,7 @@ BOOL STORMAPI _SDrawCaptureScreen(const char *pszOutput)
   if ( !pszOutput )
     return FALSE;
 
-  boost::filesystem::path newScreenFilename(pszOutput);
+  Util::Path newScreenFilename(pszOutput);
 
   if ( !screenshotFmt.empty() ) // If an extension replacement was specified
     newScreenFilename.replace_extension(screenshotFmt);

--- a/bwapi/BWAPI/Source/GameUpdate.cpp
+++ b/bwapi/BWAPI/Source/GameUpdate.cpp
@@ -1,6 +1,7 @@
 #include "GameImpl.h"
 
-#include <boost/filesystem.hpp>
+#include <Util/Path.h>
+#include <Util/StringUtil.h>
 
 #include "PlayerImpl.h"
 
@@ -16,7 +17,6 @@
 
 #include "../../../svnrev.h"
 #include "../../../Debug.h"
-#include <boost/algorithm/string/trim.hpp>
 
 using namespace BWAPI;
 
@@ -364,8 +364,8 @@ void GameImpl::initializeAIModule()
         std::getline(aiList, dll, ',');
 
       // trim whitespace outside quotations and then the quotations
-      boost::trim(dll);
-      boost::trim_if(dll, boost::is_any_of("\""));
+      Util::trim(dll, Util::is_whitespace_or_newline);
+      Util::trim(dll, [](char c) { return c == '"'; });
 
       hAIModule = LoadLibraryA(dll.c_str());
     }
@@ -400,7 +400,7 @@ void GameImpl::initializeAIModule()
         externalModuleConnected = true;
 
         // Strip the path from the module name
-        moduleName = boost::filesystem::path(dll).filename().string();
+        moduleName = Util::Path(dll).filename().string();
       }
       else  // If the AIModule function is not found
       {

--- a/bwapi/BWAPILIB/Source/BroodwarOutputDevice.cpp
+++ b/bwapi/BWAPILIB/Source/BroodwarOutputDevice.cpp
@@ -1,3 +1,4 @@
+#if 0
 #include <BWAPI/BroodwarOutputDevice.h>
 
 namespace BWAPI
@@ -33,3 +34,4 @@ namespace BWAPI
     7, 7, 7, 7, 7, 7,10, 6, 7, 7, 7, 7, 4, 3, 5, 5, 7, 6, 7, 7, 7, 7, 7, 7, 7, 6, 6, 6, 6, 7, 7, 7,
   };
 }
+#endif // 0

--- a/bwapi/BWAPILIB/Source/Streams.cpp
+++ b/bwapi/BWAPILIB/Source/Streams.cpp
@@ -1,6 +1,8 @@
 #include <BWAPI/Streams.h>
 #include <BWAPI/BroodwarOutputDevice.h>
+#include <iostream>
 
+#if 0
 #pragma warning(push)
 #pragma warning(disable: 4702) //unreachable code
 #include <boost/iostreams/stream.hpp>
@@ -10,10 +12,12 @@
 #pragma warning(disable: 4512) //assignment operator could not be generated
 #include <boost/iostreams/tee.hpp>
 #pragma warning(pop)
+#endif // 0
 
 
 namespace BWAPI
 {
+#if 0
   namespace io = boost::iostreams;
   using bwstream = io::stream<BroodwarOutputDevice>;
   using teestream = io::stream<io::tee_device<std::ostream, std::ostream>>;
@@ -28,4 +32,10 @@ namespace BWAPI
   teestream err_stream(io::tee(std::cerr, bwerr));
   std::ostream& out = out_stream;
   std::ostream& err = err_stream;
+#endif // 0
+
+  std::ostream& bwout = std::cout;
+  std::ostream& bwerr = std::cerr;
+  std::ostream& out = std::cout;
+  std::ostream& err = std::cerr;
 }

--- a/bwapi/Util/Source/Util/Clamp.h
+++ b/bwapi/Util/Source/Util/Clamp.h
@@ -1,0 +1,15 @@
+#pragma once
+/*  clamp.h
+    clamping a value to be between a specified min and max value
+*/
+#include <algorithm>
+
+namespace Util {
+
+template <typename _T>
+static inline _T clamp(const _T &val, const _T &low, const _T &high)
+{
+  return std::min(std::max(val,low), high);
+}
+
+} // Util

--- a/bwapi/Util/Source/Util/Path.h
+++ b/bwapi/Util/Source/Util/Path.h
@@ -1,0 +1,12 @@
+﻿#pragma once
+
+#include <filesystem>
+
+namespace Util {
+
+namespace FS = std::experimental::filesystem;
+
+using Path = FS::path;
+using FS::create_directories;
+
+} // Util

--- a/bwapi/Util/Source/Util/StringUtil.h
+++ b/bwapi/Util/Source/Util/StringUtil.h
@@ -1,0 +1,60 @@
+﻿#pragma once
+
+#include <functional>
+#include <algorithm>
+#include <ctype.h>
+
+namespace Util {
+
+inline std::string to_lower_copy(const std::string& s) {
+  std::string result(s);
+  std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+  return result;
+}
+
+inline std::string to_upper_copy(const std::string& s) {
+  std::string result(s);
+  std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+  return result;
+}
+
+// Trims the left side of str, using predicate to decide trimming (while true)
+inline void trim_left(std::string& str, std::function<bool(char)> pred) {
+  auto it = str.begin();
+  auto it_end = str.end();
+  // Skip first items while predicate gives true
+  while (it != it_end && pred(*it)) {
+    ++it;
+  }
+  // Drop from the beginning to here
+  str.erase(str.begin(), it);
+}
+
+// Trims the right side of str, using pred to decide trimming (while true)
+inline void trim_right(std::string& str, std::function<bool(char)> pred) {
+  auto it = str.rbegin();
+  auto it_end = str.rend();
+  // Skip last items while predicate gives true
+  while (it != it_end && pred(*it)) {
+    ++it; // reverse iterator goes back
+  }
+  // Drop from here till the end
+  str.erase(it.base(), str.end());
+}
+
+// Trims left and right side of str, using predicate to check if the character
+// stays (false) or will be trimmed (true)
+inline void trim(std::string& str, std::function<bool(char)> pred) {
+  trim_left(str, pred);
+  trim_right(str, pred);
+}
+
+//
+// Predicate for trim
+//
+
+inline bool is_whitespace_or_newline(char c) {
+  return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+} // Util

--- a/bwapi/include/BWAPI/BroodwarOutputDevice.h
+++ b/bwapi/include/BWAPI/BroodwarOutputDevice.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#if 0
 #include <BWAPI/Game.h>
 #include <sstream>
 #include <boost/circular_buffer.hpp>
@@ -83,3 +85,5 @@ namespace BWAPI
     }
   };
 }
+
+#endif // 0

--- a/bwapi/include/BWAPI/Unitset.h
+++ b/bwapi/include/BWAPI/Unitset.h
@@ -2,6 +2,7 @@
 #include "SetContainer.h"
 #include <BWAPI/Position.h>
 #include <BWAPI/Filters.h>
+#include <iterator>
 
 namespace BWAPI
 {
@@ -22,6 +23,11 @@ namespace BWAPI
     /// return value for BWAPI interface functions that have encountered an error.
     static const Unitset none;
 
+    Unitset& operator = (const Unitset& other) {
+        clear();
+        std::copy(other.begin(), other.end(), std::inserter(*this, begin()));
+        return *this;
+    }
 
     /// <summary>Calculates the average of all valid Unit positions in this set.</summary>
     ///


### PR DESCRIPTION
* Adds CMake scripts to use BWAPI and BWClient as static libraries. It is potentially able to build BWAPI DLL too, but something is not right with compile flags, starting with this DLL freezes, so i commented it out.
* Boost dependency is removed from the code (not from the VS solution)

See CMake/README.md

Creates bwapi/Release/BWAPI-Static.lib and bwapi/Debug/BWAPI-Staticd.lib
Creates bwapi/Release/BWAPIClient.lib and bwapi/Debug/BWAPIClientd.lib

Compile tested with VS2017 and VS2015.
EXE Client bot works both debug (VS Debug build) and release (VS Release build)

# TODO (Need help!)

* Broodwar output streams are commented out. Something must be done.
* NuGet packages must be removed for BWAPI, BWAPILib and BWAPIClient
* New include files should be added to VS solution, they are located in `bwapi/Utils` (Clamp.h, StringUtil.h, Path.h)