### PR TITLE
Fix crash when starting second multiplayer game with speed_override=0

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
@@ -23,6 +23,9 @@ namespace BWAPI
     // This function is called at the start of every match
     this->initializeData();
 
+    // Set the speed override
+    this->setLocalSpeedDirect(this->speedOverride);
+
     // initialize the variables
     //this->frameCount      = 0;
     this->onStartCalled   = true;

--- a/bwapi/BWAPI/Source/BWAPI/GameInternals.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameInternals.cpp
@@ -344,7 +344,7 @@ namespace BWAPI
     this->regionMap.clear();
 
     // Reset game speeds and text size
-    this->setLocalSpeedDirect(this->speedOverride);
+    this->setLocalSpeedDirect(std::numeric_limits<int>::min());
     this->setFrameSkip(1);
     this->setTextSize();
     this->setGUI(true);


### PR DESCRIPTION
This fixes a Broodwar crash when starting subsequent multiplayer games with speed_override = 0. It does this by making sure that BW's speed arrays are reset to the stock values when games finish, and setting the speed override only on game start. Applies to BWAPI 4.1.2 onwards at least.

Replicating the crash: Set speed_override = 0 in BWAPI.ini. Start a UDP or Local PC multiplayer game. Surrender. Start another game. BW should immediately crash. Doesn't matter whether you have a bot attached or computer opponents. Other network modes may also crash but are untested.
