### PR TITLE
Document weapon splash and halt distance

### DIFF
--- a/bwapi/include/BWAPI/UnitType.h
+++ b/bwapi/include/BWAPI/UnitType.h
@@ -540,12 +540,10 @@ namespace BWAPI
     /// pixel per frame.
     int acceleration() const;
 
-    /// <summary>Retrieves the unit's halting distance.</summary> This determines how fast a unit
-    /// can stop moving.
+    /// <summary>Retrieves the unit's halting distance.</summary> This is the distance from
+    /// the unit's destination at which point the unit starts decelerating.
     ///
-    /// @returns A halting distance value.
-    ///
-    /// @todo Figure out the units this quantity is measured in.
+    /// @returns The unit's halting distance, in 1/256ths of a pixel.
     int haltDistance() const;
 
     /// <summary>Retrieves a unit's turning rate.</summary> This determines how far a unit can

--- a/bwapi/include/BWAPI/WeaponType.h
+++ b/bwapi/include/BWAPI/WeaponType.h
@@ -226,25 +226,22 @@ namespace BWAPI
       /// @returns Maximum attack range, in pixels.
       int maxRange() const;
 
-      /// <summary>Retrieves the inner radius used for splash damage calculations, in pixels.</summary>
+      /// <summary>Retrieves the inner radius used for splash damage calculations, in pixels.
+      /// Units in this area take 100% damage.</summary>
       /// 
       /// @returns Radius of the inner splash area, in pixels.
-      ///
-      /// @todo Add damage calculation.
       int innerSplashRadius() const;
 
-      /// <summary>Retrieves the middle radius used for splash damage calculations, in pixels.</summary>
+      /// <summary>Retrieves the middle radius used for splash damage calculations, in pixels.
+      /// Units in this area take 50% damage.</summary>
       /// 
       /// @returns Radius of the middle splash area, in pixels.
-      ///
-      /// @todo Add damage calculation.
       int medianSplashRadius() const;
 
       /// <summary>Retrieves the outer radius used for splash damage calculations, in pixels.</summary>
+      /// Units in this area take 25% damage.</summary>
       /// 
       /// @returns Radius of the outer splash area, in pixels.
-      ///
-      /// @todo Add damage calculation.
       int outerSplashRadius() const;
 
       /// <summary>Checks if this weapon type can target air units.</summary>


### PR DESCRIPTION
Eliminating more @todos in the docs.

Splash damage source:  http://liquipedia.net/starcraft/Damage#Splash_Damage

Halt distance source: @tscmoo 