### PR TITLE
Avoid std::tie in BWAPI::Point

### DIFF
--- a/bwapi/include/BWAPI/Position.h
+++ b/bwapi/include/BWAPI/Position.h
@@ -86,8 +86,8 @@ namespace BWAPI
     explicit operator bool() const { return this->isValid(); };
     
     bool operator == (const Point<T,Scale> &pos) const
-    { 
-      return std::tie(this->x, this->y) == std::tie(pos.x, pos.y);
+    {
+      return this->x == pos.x && this->y == pos.y;
     }; 
     bool operator != (const Point<T,Scale> &pos) const
     { 
@@ -98,7 +98,9 @@ namespace BWAPI
     /// Compares lexicographically the x position, followed by the y position.
     bool operator  < (const Point<T,Scale> &position) const
     {
-      return std::tie(this->x, this->y) < std::tie(position.x, position.y);
+      if(this->x == position.x)
+        return this->y < position.y;
+      return this.x < position.x;
     };
 
     inline Point<T, Scale> &operator += (const Point<T, Scale> &p)

--- a/bwapi/include/BWAPI/Position.h
+++ b/bwapi/include/BWAPI/Position.h
@@ -100,7 +100,7 @@ namespace BWAPI
     {
       if(this->x == position.x)
         return this->y < position.y;
-      return this.x < position.x;
+      return this->x < position.x;
     };
 
     inline Point<T, Scale> &operator += (const Point<T, Scale> &p)


### PR DESCRIPTION
`std::tie` is considered impractical, slow and dangerous. While it does the job here, `std::tie` should not be used for lexicographic ordering for performance reasons in less optimized environments, like when running your bot in debug mode.

To illustrate this, I put together a small [benchmark](http://quick-bench.com/jdHro_IfUNKELMR3z9Yk2EzGVsc). The performance in Release (-O3) [is unaffected](http://quick-bench.com/-nieXCPkCW8StNYhyEX4n18_qc8).