### PR TITLE
Specified that Player.weaponDamageCooldown only applies to ground attacks

### DIFF
--- a/bwapi/include/BWAPI/Player.h
+++ b/bwapi/include/BWAPI/Player.h
@@ -521,14 +521,14 @@ namespace BWAPI
     /// @returns Sight range of the provided unit type for this player.
     int sightRange(UnitType unit) const;
 
-    /// <summary>Retrieves the weapon cooldown of a unit type, taking the player's attack speed
+    /// <summary>Retrieves the ground weapon cooldown of a unit type, taking the player's attack speed
     /// upgrades into consideration.</summary>
     ///
     /// <param name="unit">
-    ///   The UnitType to retrieve the damage cooldown for.
+    ///   The UnitType to retrieve the ground damage cooldown for.
     /// </param>
     ///
-    /// @returns Weapon cooldown of the provided unit type for this player.
+    /// @returns Ground weapon cooldown of the provided unit type for this player.
     int weaponDamageCooldown(UnitType unit) const;
 
     /// <summary>Calculates the armor that a given unit type will have, including upgrades.</summary>


### PR DESCRIPTION
Ensured weaponDamageCooldown does what it says on the tin by updating the tin.

CC @ebetica