### PR TITLE
#790 Tell Clients about player->isParticipating

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/Server.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/Server.cpp
@@ -443,6 +443,7 @@ namespace BWAPI
       p->type = i->getType();
       p->force = getForceID(i->getForce());
       p->color = p2->color;
+      p->isParticipating = p2->isParticipating;
 
       for(int j = 0; j < 12; ++j)
       {


### PR DESCRIPTION
I also audited the other fields of PlayerData; all are copied to the client either at the start of the game or on each frame.

(This PR looks better than my last attempt. :-))