### PR TITLE
Fix client desync when trying to expand to base with blocking minerals

### DIFF
--- a/bwapi/Shared/Templates.h
+++ b/bwapi/Shared/Templates.h
@@ -258,7 +258,7 @@ namespace BWAPI
         for (BWAPI::Unit m : Broodwar->getStaticMinerals())
         {
           TilePosition tp = m->getInitialTilePosition();
-          if ( (Broodwar->isVisible(tp) || Broodwar->isVisible(tp.x + 1, tp.y)) && !m->isVisible() )
+          if ( (Broodwar->isVisible(tp) || Broodwar->isVisible(tp.x + 1, tp.y)) && !m->exists() )
               continue; // tile position is visible, but mineral is not => mineral does not exist
           if (tp.x > lt.x - 5 &&
               tp.y > lt.y - 4 &&


### PR DESCRIPTION
isVisible() is not synced to a client when a unit is removed, but it is marked as nonexistent.
Clients should always check exists() on units, not doing so makes this mineral check algorithm see a ghost mineral field. This does not occur on modules since there isVisible() is properly updated.