### PR TITLE
Fixes #847

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/UnitImpl.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/UnitImpl.cpp
@@ -212,8 +212,8 @@ namespace BWAPI
       return true;
 
     //If we get here, canAccess()==true but unit is not owned by self.
-    //Return value depends on state of complete map info flag
-    return BroodwarImpl.isFlagEnabled(Flag::CompleteMapInformation);
+    //Return value depends on if unit is neutral and state of complete map info flag
+    return this->_getType.isNeutral() || BroodwarImpl.isFlagEnabled(Flag::CompleteMapInformation);
   }
 
   //--------------------------------------------- GET NEXT ---------------------------------------------------

--- a/bwapi/BWAPI/Source/BWAPI/UnitImpl.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/UnitImpl.cpp
@@ -212,8 +212,8 @@ namespace BWAPI
       return true;
 
     //If we get here, canAccess()==true but unit is not owned by self.
-    //Return value depends on if unit is neutral and state of complete map info flag
-    return this->_getType.isNeutral() || BroodwarImpl.isFlagEnabled(Flag::CompleteMapInformation);
+    //Return value depends on if unit is a mineral field or vespene geyser and the state of complete map info flag
+    return this->_getType.isMineralField() || this->_getType == BWAPI::UnitTypes::Resource_Vespene_Geyser || BroodwarImpl.isFlagEnabled(Flag::CompleteMapInformation);
   }
 
   //--------------------------------------------- GET NEXT ---------------------------------------------------

--- a/bwapi/BWAPI/Source/BWAPI/UnitUpdate.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/UnitUpdate.cpp
@@ -276,12 +276,6 @@ namespace BWAPI
       self->lastHitPoints       = wasAccessible ? self->hitPoints : _getHitPoints;  //getHitPoints
       self->hitPoints           = _getHitPoints;  //getHitPoints
       self->shields             = _getType.maxShields() > 0 ? (int)std::ceil(o->shieldPoints/256.0) : 0;  //getShields
-
-      //getResources
-      if (this->_getPlayer == BroodwarImpl.self() || this->_getType.isNeutral()) {
-        self->resources = _getResources;
-      } else self->resources = getInitialResources();
-
       self->resourceGroup       = _getType.isResourceContainer() ? o->resource.resourceGroup : 0; //getResourceGroup
       self->killCount           = o->killCount;        //getKillCount
       self->acidSporeCount      = o->status.acidSporeCount;   //getAcidSporeCount
@@ -525,6 +519,10 @@ namespace BWAPI
       self->rallyUnit             = -1;
       
       //------------------------------------------------------------------------------------------------------
+      // getResources
+      self->resources = _getResources;
+
+      //------------------------------------------------------------------------------------------------------
       // getEnergy
       self->energy = _getType.isSpellcaster() ? (int)std::ceil(o->energy / 256.0) : 0;
 
@@ -634,6 +632,7 @@ namespace BWAPI
     }
     else
     {
+      self->resources = getInitialResources();            //getResources
       self->energy                = 0;                    //getEnergy
       self->buildType             = UnitTypes::None;     //getBuildType
       self->trainingQueueCount    = 0;                    //getTrainingQueue

--- a/bwapi/BWAPI/Source/BWAPI/UnitUpdate.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/UnitUpdate.cpp
@@ -276,7 +276,12 @@ namespace BWAPI
       self->lastHitPoints       = wasAccessible ? self->hitPoints : _getHitPoints;  //getHitPoints
       self->hitPoints           = _getHitPoints;  //getHitPoints
       self->shields             = _getType.maxShields() > 0 ? (int)std::ceil(o->shieldPoints/256.0) : 0;  //getShields
-      self->resources           = _getResources;                        //getResources
+	  
+	  //getResources																									  
+	  if (this->_getPlayer == BroodwarImpl.self() || this->_getType.isNeutral()) {
+		  self->resources = _getResources;
+	  } else self->resources = getInitialResources();
+
       self->resourceGroup       = _getType.isResourceContainer() ? o->resource.resourceGroup : 0; //getResourceGroup
       self->killCount           = o->killCount;        //getKillCount
       self->acidSporeCount      = o->status.acidSporeCount;   //getAcidSporeCount

--- a/bwapi/BWAPI/Source/BWAPI/UnitUpdate.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/UnitUpdate.cpp
@@ -276,11 +276,11 @@ namespace BWAPI
       self->lastHitPoints       = wasAccessible ? self->hitPoints : _getHitPoints;  //getHitPoints
       self->hitPoints           = _getHitPoints;  //getHitPoints
       self->shields             = _getType.maxShields() > 0 ? (int)std::ceil(o->shieldPoints/256.0) : 0;  //getShields
-	  
-	  //getResources																									  
-	  if (this->_getPlayer == BroodwarImpl.self() || this->_getType.isNeutral()) {
-		  self->resources = _getResources;
-	  } else self->resources = getInitialResources();
+
+      //getResources
+      if (this->_getPlayer == BroodwarImpl.self() || this->_getType.isNeutral()) {
+        self->resources = _getResources;
+      } else self->resources = getInitialResources();
 
       self->resourceGroup       = _getType.isResourceContainer() ? o->resource.resourceGroup : 0; //getResourceGroup
       self->killCount           = o->killCount;        //getKillCount

--- a/bwapi/Shared/UnitShared.cpp
+++ b/bwapi/Shared/UnitShared.cpp
@@ -85,9 +85,7 @@ namespace BWAPI
   //--------------------------------------------- GET RESOURCES ----------------------------------------------
   int UnitImpl::getResources() const
   {
-	  if (Broodwar->self() == getPlayer() || getType().isNeutral())
-		return self->resources;
-	  return getInitialResources();
+	  return self->resources;
   }
   //--------------------------------------------- GET RESOURCE GROUP -----------------------------------------
   int UnitImpl::getResourceGroup() const

--- a/bwapi/Shared/UnitShared.cpp
+++ b/bwapi/Shared/UnitShared.cpp
@@ -85,7 +85,7 @@ namespace BWAPI
   //--------------------------------------------- GET RESOURCES ----------------------------------------------
   int UnitImpl::getResources() const
   {
-	  return self->resources;
+    return self->resources;
   }
   //--------------------------------------------- GET RESOURCE GROUP -----------------------------------------
   int UnitImpl::getResourceGroup() const

--- a/bwapi/Shared/UnitShared.cpp
+++ b/bwapi/Shared/UnitShared.cpp
@@ -87,7 +87,7 @@ namespace BWAPI
   {
 	  if (Broodwar->self() == getPlayer() || getType().isNeutral())
 		return self->resources;
-	  return 0;
+	  return getInitialResources();
   }
   //--------------------------------------------- GET RESOURCE GROUP -----------------------------------------
   int UnitImpl::getResourceGroup() const

--- a/bwapi/Shared/UnitShared.cpp
+++ b/bwapi/Shared/UnitShared.cpp
@@ -85,7 +85,9 @@ namespace BWAPI
   //--------------------------------------------- GET RESOURCES ----------------------------------------------
   int UnitImpl::getResources() const
   {
-    return self->resources;
+	  if (Broodwar->self() == getPlayer() || getType().isNeutral())
+		return self->resources;
+	  return 0;
   }
   //--------------------------------------------- GET RESOURCE GROUP -----------------------------------------
   int UnitImpl::getResourceGroup() const


### PR DESCRIPTION
This should fix issue #847 

Fresh 4.4 without the fix:

![image](https://user-images.githubusercontent.com/17556613/72997455-b4a53400-3dfc-11ea-9607-e9c41f80f2db.png)

Fixed 4.4:

![image](https://user-images.githubusercontent.com/17556613/72997396-99d2bf80-3dfc-11ea-90ab-66ecdad682ac.png)

Getting resource amount from own refinery works fine too:

![image](https://user-images.githubusercontent.com/17556613/72997811-254c5080-3dfd-11ea-86e1-f25d02e44386.png)

Code used to test:

```cpp
void ExampleAIModule::onFrame()
{
  for (auto& u : Broodwar->getAllUnits())
  {
	  if (u->getType().isRefinery()) {
		  std::string s = std::to_string(u->getInitialResources());
		  std::string s2 = std::to_string(u->getResources());
		  Broodwar->drawTextMap(u->getInitialPosition(), s.c_str(), Colors::White);
		  Broodwar->drawTextMap(u->getInitialPosition() + Position(0, 16), s2.c_str(), Colors::White);
	  }
  }
}
```