### PR TITLE
Add more ways to provide settings to DirectIP SNP

### DIFF
--- a/1.16.1/SNP_DirectIP/src/DirectIP/DirectIP.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/DirectIP.cpp
@@ -12,7 +12,7 @@ namespace DRIP
     // CAPS:
   {sizeof(SNETCAPS), SNET_CAPS_RETAILONLY | SNET_CAPS_BASICINTERFACE | SNET_CAPS_PAGELOCKEDBUFFERS, SNP::PACKET_SIZE, 16, 256, 1000, 50, 8, 2}};
 
-  Settings *settings;
+  std::unique_ptr<Settings> settings;
   UDPSocket session;
 
   // ----------------- game list section -----------------------
@@ -30,7 +30,7 @@ namespace DRIP
   //------------------------------------------------------------------------------------------------------------------------------------
   void rebind()
   {
-    int targetPort = atoi(settings->getLocalPortString());
+    int targetPort = settings->getLocalPort();
     if(session.getBoundPort() == targetPort)
       return;
     try
@@ -120,7 +120,6 @@ namespace DRIP
   void DirectIP::destroy()
   {
     settings->release();
-    delete settings;
     session.release();
   }
 
@@ -138,7 +137,7 @@ namespace DRIP
     UDPAddr host;
     host.sin_family = AF_INET;
     host.sin_addr.s_addr = inet_addr(settings->getHostIPString());
-    host.sin_port = htons(atoi(settings->getHostPortString()));
+    host.sin_port = htons(settings->getHostPort());
     session.sendPacket(host, sendBuffer.getFrameUpto(ping_server));
   }
   void DirectIP::sendAsyn(const SNETADDR& him, Util::MemoryFrame packet)

--- a/1.16.1/SNP_DirectIP/src/DirectIP/DirectIP.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/DirectIP.cpp
@@ -4,6 +4,7 @@
 #include "../SNP/Output.h"
 #include "UDPSocket.h"
 #include "SettingsDialog.h"
+#include "SettingsFile.h"
 
 namespace DRIP
 {
@@ -11,6 +12,7 @@ namespace DRIP
     // CAPS:
   {sizeof(SNETCAPS), SNET_CAPS_RETAILONLY | SNET_CAPS_BASICINTERFACE | SNET_CAPS_PAGELOCKEDBUFFERS, SNP::PACKET_SIZE, 16, 256, 1000, 50, 8, 2}};
 
+  Settings *settings;
   UDPSocket session;
 
   // ----------------- game list section -----------------------
@@ -28,7 +30,7 @@ namespace DRIP
   //------------------------------------------------------------------------------------------------------------------------------------
   void rebind()
   {
-    int targetPort = atoi(getLocalPortString());
+    int targetPort = atoi(settings->getLocalPortString());
     if(session.getBoundPort() == targetPort)
       return;
     try
@@ -37,11 +39,11 @@ namespace DRIP
       session.init();
       session.setBlockingMode(false);
       session.bind(targetPort);
-      setStatusString("network ready");
+      settings->setStatusString("network ready");
     }
     catch(...)
     {
-      setStatusString("local port fail");
+      settings->setStatusString("local port fail");
     }
   }
   void DirectIP::processIncomingPackets()
@@ -58,7 +60,7 @@ namespace DRIP
         {
           if(session.getState() == WSAECONNRESET)
           {
-            setStatusString("host IP not reachable");
+            settings->setStatusString("host IP not reachable");
             continue;
           }
           if(session.getState() == WSAEWOULDBLOCK)
@@ -108,16 +110,20 @@ namespace DRIP
   //------------------------------------------------------------------------------------------------------------------------------------
   void DirectIP::initialize()
   {
-    showSettingsDialog();
+      settings = Settings::getSettings();
+      settings->init();
 
     // bind to port
     rebind();
   }
+
   void DirectIP::destroy()
   {
-    hideSettingsDialog();
+    settings->release();
+    delete settings;
     session.release();
   }
+
   void DirectIP::requestAds()
   {
     rebind();
@@ -131,8 +137,8 @@ namespace DRIP
 
     UDPAddr host;
     host.sin_family = AF_INET;
-    host.sin_addr.s_addr = inet_addr(getHostIPString());
-    host.sin_port = htons(u_short(std::atoi(getHostPortString())));
+    host.sin_addr.s_addr = inet_addr(settings->getHostIPString());
+    host.sin_port = htons(atoi(settings->getHostPortString()));
     session.sendPacket(host, sendBuffer.getFrameUpto(ping_server));
   }
   void DirectIP::sendAsyn(const SNETADDR& him, Util::MemoryFrame packet)

--- a/1.16.1/SNP_DirectIP/src/DirectIP/Settings.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/Settings.cpp
@@ -7,8 +7,8 @@
 #include "SettingsDialog.h"
 #include "SettingsEnvironment.h"
 
-Settings* Settings::getSettings() {
-	SettingsEnvironment* envSettings = new SettingsEnvironment();
+std::unique_ptr<Settings> Settings::getSettings() {
+	unique_ptr<SettingsEnvironment> envSettings = make_unique<SettingsEnvironment>();
 	if (envSettings->isOk()) {
 		return envSettings;
 	}
@@ -18,9 +18,9 @@ Settings* Settings::getSettings() {
 
 	std::ifstream settingsFile("directip.conf", std::ifstream::in);
 	if (settingsFile.good()) {
-		return new SettingsFile(settingsFile);
+		return make_unique<SettingsFile>(settingsFile);
 	}
 	else {
-		return new SettingsDialog();
+		return make_unique<SettingsDialog>();
 	}
 }

--- a/1.16.1/SNP_DirectIP/src/DirectIP/Settings.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/Settings.cpp
@@ -1,0 +1,26 @@
+#include "Settings.h"
+
+#include <iostream>
+#include <fstream>
+
+#include "SettingsFile.h"
+#include "SettingsDialog.h"
+#include "SettingsEnvironment.h"
+
+Settings* Settings::getSettings() {
+	SettingsEnvironment* envSettings = new SettingsEnvironment();
+	if (envSettings->isOk()) {
+		return envSettings;
+	}
+	else {
+		delete envSettings;
+	}
+
+	std::ifstream settingsFile("directip.conf", std::ifstream::in);
+	if (settingsFile.good()) {
+		return new SettingsFile(settingsFile);
+	}
+	else {
+		return new SettingsDialog();
+	}
+}

--- a/1.16.1/SNP_DirectIP/src/DirectIP/Settings.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/Settings.cpp
@@ -8,19 +8,16 @@
 #include "SettingsEnvironment.h"
 
 std::unique_ptr<Settings> Settings::getSettings() {
-	unique_ptr<SettingsEnvironment> envSettings = make_unique<SettingsEnvironment>();
+	std::unique_ptr<SettingsEnvironment> envSettings = std::make_unique<SettingsEnvironment>();
 	if (envSettings->isOk()) {
 		return envSettings;
-	}
-	else {
-		delete envSettings;
 	}
 
 	std::ifstream settingsFile("directip.conf", std::ifstream::in);
 	if (settingsFile.good()) {
-		return make_unique<SettingsFile>(settingsFile);
+		return std::make_unique<SettingsFile>(settingsFile);
 	}
 	else {
-		return make_unique<SettingsDialog>();
+		return std::make_unique<SettingsDialog>();
 	}
 }

--- a/1.16.1/SNP_DirectIP/src/DirectIP/Settings.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/Settings.h
@@ -1,0 +1,19 @@
+#pragma once
+
+class Settings
+{
+public:
+	Settings() {};
+	virtual ~Settings() {};
+
+	virtual void init() = 0;
+	virtual void release() = 0;
+
+	virtual const char* getHostIPString() = 0;
+	virtual const char* getHostPortString() = 0;
+	virtual const char* getLocalPortString() = 0;
+	virtual void setStatusString(const char* statusText) = 0;
+
+	static Settings* getSettings();
+};
+

--- a/1.16.1/SNP_DirectIP/src/DirectIP/Settings.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/Settings.h
@@ -12,8 +12,8 @@ public:
 	virtual void release() = 0;
 
 	virtual const char* getHostIPString() const = 0;
-	virtual const u_short getHostPort() const = 0;
-	virtual const u_short getLocalPort() const = 0;
+	virtual const uint16_t getHostPort() const = 0;
+	virtual const uint16_t getLocalPort() const = 0;
 	virtual void setStatusString(const char* statusText) = 0;
 
 	static std::unique_ptr<Settings> getSettings();

--- a/1.16.1/SNP_DirectIP/src/DirectIP/Settings.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/Settings.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 class Settings
 {
 public:
@@ -9,11 +11,11 @@ public:
 	virtual void init() = 0;
 	virtual void release() = 0;
 
-	virtual const char* getHostIPString() = 0;
-	virtual const char* getHostPortString() = 0;
-	virtual const char* getLocalPortString() = 0;
+	virtual const char* getHostIPString() const = 0;
+	virtual const u_short getHostPort() const = 0;
+	virtual const u_short getLocalPort() const = 0;
 	virtual void setStatusString(const char* statusText) = 0;
 
-	static Settings* getSettings();
+	static std::unique_ptr<Settings> getSettings();
 };
 

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.cpp
@@ -39,7 +39,7 @@ void SettingsDialog::hideSettingsDialog()
   }
 }
 
-const char* SettingsDialog::getHostIPString()
+const char* SettingsDialog::getHostIPString() const
 {
   static char buffer[32];
   if(hDlg)
@@ -49,24 +49,24 @@ const char* SettingsDialog::getHostIPString()
   return buffer;
 }
 
-const char* SettingsDialog::getHostPortString()
+const u_short SettingsDialog::getHostPort() const
 {
   static char buffer[32];
   if(hDlg)
   {
     GetDlgItemTextA(hDlg, IDC_EDITPORT, buffer, 32);
   }
-  return buffer;
+  return std::strtoul(buffer, buffer+32, 10);
 }
 
-const char* SettingsDialog::getLocalPortString()
+const u_short SettingsDialog::getLocalPort() const
 {
   static char buffer[32];
   if(hDlg)
   {
     GetDlgItemTextA(hDlg, IDC_EDITLPORT, buffer, 32);
   }
-  return buffer;
+  return std::strtoul(buffer, buffer+32, 10);
 }
 
 void SettingsDialog::setStatusString(const char *statusText)

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.cpp
@@ -49,24 +49,24 @@ const char* SettingsDialog::getHostIPString() const
   return buffer;
 }
 
-const u_short SettingsDialog::getHostPort() const
+const uint16_t SettingsDialog::getHostPort() const
 {
   static char buffer[32];
   if(hDlg)
   {
     GetDlgItemTextA(hDlg, IDC_EDITPORT, buffer, 32);
   }
-  return std::strtoul(buffer, buffer+32, 10);
+  return (uint16_t)std::strtoul(buffer, nullptr, 10);
 }
 
-const u_short SettingsDialog::getLocalPort() const
+const uint16_t SettingsDialog::getLocalPort() const
 {
   static char buffer[32];
   if(hDlg)
   {
     GetDlgItemTextA(hDlg, IDC_EDITLPORT, buffer, 32);
   }
-  return std::strtoul(buffer, buffer+32, 10);
+  return (uint16_t)std::strtoul(buffer, nullptr, 10);
 }
 
 void SettingsDialog::setStatusString(const char *statusText)

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.cpp
@@ -1,13 +1,9 @@
 #include "SettingsDialog.h"
-#include <windows.h>
-
-#include "../../resource.h"
 
 INT_PTR CALLBACK Settings( HWND, UINT, WPARAM, LPARAM );
 DWORD WINAPI dlgThread(LPVOID lpParameter);
 
-HANDLE hdlgThread = NULL;
-HWND hDlg = NULL;
+HWND hDlg;
 
 extern HINSTANCE hInstance;
 
@@ -17,12 +13,23 @@ DWORD WINAPI dlgThread(LPVOID lpParameter)
   return 0;
 }
 
-void showSettingsDialog()
+SettingsDialog::SettingsDialog() : hdlgThread(NULL) {}
+SettingsDialog::~SettingsDialog() {}
+
+void SettingsDialog::init() {
+    showSettingsDialog();
+}
+
+void SettingsDialog::release() {
+    hideSettingsDialog();
+}
+
+void SettingsDialog::showSettingsDialog()
 {
   hdlgThread = CreateThread(NULL, NULL, dlgThread, NULL, NULL, NULL);
 }
 
-void hideSettingsDialog()
+void SettingsDialog::hideSettingsDialog()
 {
   if(hdlgThread)
   {
@@ -32,7 +39,7 @@ void hideSettingsDialog()
   }
 }
 
-const char* getHostIPString()
+const char* SettingsDialog::getHostIPString()
 {
   static char buffer[32];
   if(hDlg)
@@ -42,7 +49,7 @@ const char* getHostIPString()
   return buffer;
 }
 
-const char* getHostPortString()
+const char* SettingsDialog::getHostPortString()
 {
   static char buffer[32];
   if(hDlg)
@@ -52,7 +59,7 @@ const char* getHostPortString()
   return buffer;
 }
 
-const char* getLocalPortString()
+const char* SettingsDialog::getLocalPortString()
 {
   static char buffer[32];
   if(hDlg)
@@ -62,13 +69,14 @@ const char* getLocalPortString()
   return buffer;
 }
 
-void setStatusString(const char *statusText)
+void SettingsDialog::setStatusString(const char *statusText)
 {
   if(hDlg)
   {
     SetDlgItemTextA(hDlg, IDC_STATUS, statusText);
   }
 }
+
 
 INT_PTR CALLBACK Settings( HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.h
@@ -23,7 +23,7 @@ public:
 	void release() override;
 
 	const char* getHostIPString() const override;
-	const u_short getHostPort() const override;
-	const u_short getLocalPort() const override;
+	const uint16_t getHostPort() const override;
+	const uint16_t getLocalPort() const override;
 	void setStatusString(const char* statusText) override;
 };

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.h
@@ -3,7 +3,7 @@
 #include "Settings.h"
 
 #include <windows.h>
-#include "resource.h"
+#include "../../resource.h"
 
 
 class SettingsDialog : public Settings

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.h
@@ -1,9 +1,29 @@
 #pragma once
 
-void showSettingsDialog();
-void hideSettingsDialog();
+#include "Settings.h"
 
-const char* getHostIPString();
-const char* getHostPortString();
-const char* getLocalPortString();
-void setStatusString(const char *statusText);
+#include <windows.h>
+#include "resource.h"
+
+
+class SettingsDialog : public Settings
+{
+private:
+	HANDLE hdlgThread;
+
+
+	void showSettingsDialog();
+	void hideSettingsDialog();
+
+public:
+	SettingsDialog();
+	virtual ~SettingsDialog();
+
+	void init() override;
+	void release() override;
+
+	const char* getHostIPString() override;
+	const char* getHostPortString() override;
+	const char* getLocalPortString() override;
+	void setStatusString(const char* statusText) override;
+};

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsDialog.h
@@ -22,8 +22,8 @@ public:
 	void init() override;
 	void release() override;
 
-	const char* getHostIPString() override;
-	const char* getHostPortString() override;
-	const char* getLocalPortString() override;
+	const char* getHostIPString() const override;
+	const u_short getHostPort() const override;
+	const u_short getLocalPort() const override;
 	void setStatusString(const char* statusText) override;
 };

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.cpp
@@ -1,15 +1,15 @@
 #include "SettingsEnvironment.h"
 
 void SettingsEnvironment::FetchEnvironmentVariable(LPCTSTR name, std::string& res) {
-	DWORD bufferSize = 0xFFFF; //Limit according to http://msdn.microsoft.com/en-us/library/ms683188.aspx
-	res.resize(bufferSize);
-	bufferSize = GetEnvironmentVariableA(name, &res[0], bufferSize);
-	if (!bufferSize) {
+	DWORD bufferSize = GetEnvironmentVariable(name, nullptr, 0);
+	if (bufferSize > 0) {
+		res.resize(bufferSize + 1);
+		bufferSize = GetEnvironmentVariable(name, res.data(), res.size());
+		res.pop_back(); // Get rid of null terminator
+	} else {
 		ok = false;
 		res = "";
-		return;
 	}
-	res.resize(bufferSize);
 }
 
 SettingsEnvironment::SettingsEnvironment() : ok(true) {
@@ -23,14 +23,14 @@ SettingsEnvironment::~SettingsEnvironment() {}
 void SettingsEnvironment::init() {}
 void SettingsEnvironment::release() {}
 
-const char* SettingsEnvironment::getHostIPString() {
+const char* SettingsEnvironment::getHostIPString() const {
 	return hostIp.c_str();
 }
-const char* SettingsEnvironment::getHostPortString() {
-	return hostPort.c_str();
+const u_short SettingsEnvironment::getHostPort() const {
+	return std::stoul(hostPort);
 }
-const char* SettingsEnvironment::getLocalPortString() {
-	return localPort.c_str();
+const u_short SettingsEnvironment::getLocalPort() const {
+	return std::stoul(localPort);
 }
 void SettingsEnvironment::setStatusString(const char* statusText) {
 

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.cpp
@@ -26,10 +26,10 @@ void SettingsEnvironment::release() {}
 const char* SettingsEnvironment::getHostIPString() const {
 	return hostIp.c_str();
 }
-const u_short SettingsEnvironment::getHostPort() const {
+const uint16_t SettingsEnvironment::getHostPort() const {
 	return std::stoul(hostPort);
 }
-const u_short SettingsEnvironment::getLocalPort() const {
+const uint16_t SettingsEnvironment::getLocalPort() const {
 	return std::stoul(localPort);
 }
 void SettingsEnvironment::setStatusString(const char* statusText) {

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.cpp
@@ -1,0 +1,41 @@
+#include "SettingsEnvironment.h"
+
+void SettingsEnvironment::FetchEnvironmentVariable(LPCTSTR name, std::string& res) {
+	DWORD bufferSize = 0xFFFF; //Limit according to http://msdn.microsoft.com/en-us/library/ms683188.aspx
+	res.resize(bufferSize);
+	bufferSize = GetEnvironmentVariableA(name, &res[0], bufferSize);
+	if (!bufferSize) {
+		ok = false;
+		res = "";
+		return;
+	}
+	res.resize(bufferSize);
+}
+
+SettingsEnvironment::SettingsEnvironment() : ok(true) {
+	FetchEnvironmentVariable("BW_HOST_IP", hostIp);
+	FetchEnvironmentVariable("BW_HOST_PORT", hostPort);
+	FetchEnvironmentVariable("BW_LOCAL_PORT", localPort);
+}
+SettingsEnvironment::~SettingsEnvironment() {}
+
+
+void SettingsEnvironment::init() {}
+void SettingsEnvironment::release() {}
+
+const char* SettingsEnvironment::getHostIPString() {
+	return hostIp.c_str();
+}
+const char* SettingsEnvironment::getHostPortString() {
+	return hostPort.c_str();
+}
+const char* SettingsEnvironment::getLocalPortString() {
+	return localPort.c_str();
+}
+void SettingsEnvironment::setStatusString(const char* statusText) {
+
+}
+
+bool SettingsEnvironment::isOk() const {
+	return ok;
+}

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "Settings.h"
+
+#include <string>
+#include <windows.h>
+
+class SettingsEnvironment :
+    public Settings
+{
+
+private:
+	bool ok;
+	std::string hostIp;
+	std::string hostPort;
+	std::string localPort;
+
+	void FetchEnvironmentVariable(LPCTSTR name, std::string& res);
+
+public:
+	SettingsEnvironment();
+	virtual ~SettingsEnvironment();
+
+	void init() override;
+	void release() override;
+
+	const char* getHostIPString() override;
+	const char* getHostPortString() override;
+	const char* getLocalPortString() override;
+	void setStatusString(const char* statusText) override;
+
+	bool isOk() const;
+};

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.h
@@ -24,8 +24,8 @@ public:
 	void release() override;
 
 	const char* getHostIPString() const override;
-	const u_short getHostPort() const override;
-	const u_short getLocalPort() const override;
+	const uint16_t getHostPort() const override;
+	const uint16_t getLocalPort() const override;
 	void setStatusString(const char* statusText) override;
 
 	bool isOk() const;

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsEnvironment.h
@@ -23,9 +23,9 @@ public:
 	void init() override;
 	void release() override;
 
-	const char* getHostIPString() override;
-	const char* getHostPortString() override;
-	const char* getLocalPortString() override;
+	const char* getHostIPString() const override;
+	const u_short getHostPort() const override;
+	const u_short getLocalPort() const override;
 	void setStatusString(const char* statusText) override;
 
 	bool isOk() const;

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.cpp
@@ -1,0 +1,22 @@
+#include "SettingsFile.h"
+
+SettingsFile::SettingsFile(std::ifstream &settingsFile) {
+	settingsFile >> hostIp >> hostPort >> localPort;
+}
+SettingsFile::~SettingsFile() {}
+
+void SettingsFile::init() {}
+void SettingsFile::release() {}
+
+const char* SettingsFile::getHostIPString() {
+	return hostIp.c_str();
+}
+const char* SettingsFile::getHostPortString() {
+	return hostPort.c_str();
+}
+const char* SettingsFile::getLocalPortString() {
+	return localPort.c_str();
+}
+void SettingsFile::setStatusString(const char* statusText) {
+
+}

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.cpp
@@ -8,14 +8,14 @@ SettingsFile::~SettingsFile() {}
 void SettingsFile::init() {}
 void SettingsFile::release() {}
 
-const char* SettingsFile::getHostIPString() {
+const char* SettingsFile::getHostIPString() const {
 	return hostIp.c_str();
 }
-const char* SettingsFile::getHostPortString() {
-	return hostPort.c_str();
+const u_short SettingsFile::getHostPort() const {
+	return std::stoul(hostPort);
 }
-const char* SettingsFile::getLocalPortString() {
-	return localPort.c_str();
+const u_short SettingsFile::getLocalPort() const {
+	return std::stoul(localPort);
 }
 void SettingsFile::setStatusString(const char* statusText) {
 

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.cpp
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.cpp
@@ -11,10 +11,10 @@ void SettingsFile::release() {}
 const char* SettingsFile::getHostIPString() const {
 	return hostIp.c_str();
 }
-const u_short SettingsFile::getHostPort() const {
+const uint16_t SettingsFile::getHostPort() const {
 	return std::stoul(hostPort);
 }
-const u_short SettingsFile::getLocalPort() const {
+const uint16_t SettingsFile::getLocalPort() const {
 	return std::stoul(localPort);
 }
 void SettingsFile::setStatusString(const char* statusText) {

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Settings.h"
+
+#include <string>
+#include <fstream>
+
+class SettingsFile : public Settings
+{
+private:
+	std::string hostIp;
+	std::string hostPort;
+	std::string localPort;
+
+public:
+	SettingsFile(std::ifstream& settingsFile);
+	virtual ~SettingsFile();
+
+	void init() override;
+	void release() override;
+
+	const char* getHostIPString() override;
+	const char* getHostPortString() override;
+	const char* getLocalPortString() override;
+	void setStatusString(const char* statusText) override;
+};

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.h
@@ -19,8 +19,8 @@ public:
 	void init() override;
 	void release() override;
 
-	const char* getHostIPString() override;
-	const char* getHostPortString() override;
-	const char* getLocalPortString() override;
+	const char* getHostIPString() const override;
+	const u_short getHostPort() const override;
+	const u_short getLocalPort() const override;
 	void setStatusString(const char* statusText) override;
 };

--- a/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.h
+++ b/1.16.1/SNP_DirectIP/src/DirectIP/SettingsFile.h
@@ -20,7 +20,7 @@ public:
 	void release() override;
 
 	const char* getHostIPString() const override;
-	const u_short getHostPort() const override;
-	const u_short getLocalPort() const override;
+	const uint16_t getHostPort() const override;
+	const uint16_t getLocalPort() const override;
 	void setStatusString(const char* statusText) override;
 };


### PR DESCRIPTION
Ported https://github.com/bwapi/bwapi/pull/883 to the `develop` branch. This allows configuring the DirectIP SNP with either a config file or environment variables which makes automation easier. For example, I use this https://zeta-two.com/challenges to automate bots joining games.