### PR TITLE
Increase packet buffer, to prevent saturation

### DIFF
--- a/1.16.1/SNP_DirectIP/src/LocalPC/LocalPC.cpp
+++ b/1.16.1/SNP_DirectIP/src/LocalPC/LocalPC.cpp
@@ -27,7 +27,7 @@ namespace SMEM
     char ad[512];
     bool isAdvertising;
     int incomingCount;
-    Packet incoming[16];
+    Packet incoming[2048];
 
     bool inline isOccupied() const
     {
@@ -142,9 +142,9 @@ namespace SMEM
     // push the packet on target's packetqueue
     PeerData &peerData = shd->peer[peerid];
     int slotIndex = peerData.incomingCount++;
-    if(slotIndex >= 16)
+    if(slotIndex >= 2048)
     {
-      DropMessage(1, "stacked 16 packets, no space");
+      DropMessage(1, "stacked 2048 packets, no space");
       return;
     }
     if(packet.size() > 508)


### PR DESCRIPTION
Copied from original PR #886 :
During my tests I found that even 5-6 bots seem to saturate the small buffer. That leads to spurious crashes or inability to join games in the first place.
I did try with 32, which still was not enough - so I upped it to ~1Meg, maybe it's a bit much but even 8 bots did not trigger any warning in a full game.