### PR TITLE
Use high-resolution clock when computing lastEventTime

### DIFF
--- a/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/GameEvents.cpp
@@ -1,5 +1,6 @@
 #include "GameImpl.h"
 #include <ctime>
+#include <chrono>
 
 #include <Util/Path.h>
 #include <Util/StringUtil.h>
@@ -503,13 +504,13 @@ namespace BWAPI
       return;
     for (Event e : events)
     {
-      static DWORD dwLastEventTime = 0;
+      static std::chrono::time_point<std::chrono::high_resolution_clock> lastEventStart;
 
       // Reset event stopwatch
       if ( tournamentAI )
       {
         this->lastEventTime = 0;
-        dwLastEventTime     = GetTickCount();
+        lastEventStart      = std::chrono::high_resolution_clock::now();
       }
 
       // Send event to the AI Client module
@@ -520,7 +521,8 @@ namespace BWAPI
         continue;
 
       // Save the last event time
-      this->lastEventTime = GetTickCount() - dwLastEventTime;
+      auto const duration = std::chrono::high_resolution_clock::now() - lastEventStart;
+      this->lastEventTime = (int)std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
 
       // Send same event to the Tournament module for post-processing
       isTournamentCall = true;

--- a/bwapi/BWAPI/Source/BWAPI/Server.cpp
+++ b/bwapi/BWAPI/Source/BWAPI/Server.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <sstream>
 #include <AclAPI.h>
+#include <chrono>
 
 #include "GameImpl.h"
 #include "PlayerImpl.h"
@@ -238,9 +239,10 @@ namespace BWAPI
     {
       // Update BWAPI Client
       updateSharedMemory();
-      auto const onFrameStart = GetTickCount();
+      auto const onFrameStart = std::chrono::high_resolution_clock::now();
       callOnFrame();
-      BroodwarImpl.setLastEventTime(GetTickCount() - onFrameStart);
+      auto const duration = std::chrono::high_resolution_clock::now() - onFrameStart;
+      BroodwarImpl.setLastEventTime((int)std::chrono::duration_cast<std::chrono::milliseconds>(duration).count());
       processCommands();
     }
     else


### PR DESCRIPTION
This is a very simple PR intended to address the timer resolution issue discussed on #860.

I created the PR against the main branch since I think it makes sense to patch this in BWAPI 4.X, seeing as how timeouts continue to be an issue in tournaments held since the issue was raised.