### PR TITLE
Rename SSCAIT Discord link to Brood War AI Discord in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ AI tournaments). Changed defaults will be advertised when the match begins.
 * **Repository:**            https://github.com/bwapi/bwapi
 * **Issue Tracker:**         https://github.com/bwapi/bwapi/issues
 * **Releases:**              https://github.com/bwapi/bwapi/releases
-* **SSCAIT Discord:**        https://discord.gg/DqvHsq9
+* **Brood War AI Discord (formerly SSCAIT):** https://discord.gg/DqvHsq9
 * **IRC Channel:**           http://webchat.freenode.net/?channels=BWAPI
 * **Facebook:**              https://www.facebook.com/groups/bwapi/
 * **Links to competitions, bots, etc. :**    https://github.com/bwapi/bwapi/wiki/Useful-Links


### PR DESCRIPTION
Updates the README's Discord link label from "SSCAIT Discord" to "Brood War AI Discord" to reflect the [rename](https://discord.com/channels/327968006779174913/327968006779174913/1436559225361797141) of the community server.